### PR TITLE
Use standard Fortran90 functions to parse command line arguments 

### DIFF
--- a/src/Need/determinefilenames.f
+++ b/src/Need/determinefilenames.f
@@ -6,9 +6,9 @@
 c--- work out the name of the input file and return it
 
 
-      nargs=iargc()
+      nargs = command_argument_count()
       if (nargs .ge. 1) then
-        call getarg(1,inputfile)
+        call get_command_argument(1, inputfile)
       else
         inputfile='input.DAT'
       endif

--- a/src/Need/read_jetcuts.f
+++ b/src/Need/read_jetcuts.f
@@ -16,9 +16,9 @@ c      if (newinput) then
         return
 c      endif
       
-      nargs=iargc()
+      nargs = command_argument_count()
       if (nargs .eq. 2) then
-      call getarg(2,jetcutsfile)
+      call get_command_argument(2,jetcutsfile)
       else
       jetcutsfile='jetcuts.DAT'
       endif      


### PR DESCRIPTION
Use standard Fortran90 functions to parse command line arguments instead of GNU extensions.
GNU extensions create problems for some compilers.