### PR TITLE
Use standard conforming exit function instead of return

### DIFF
--- a/src/Need/mergedata.f90
+++ b/src/Need/mergedata.f90
@@ -211,7 +211,9 @@ program merge_gnuplot_data
      endif
   enddo
 
-  if (maxupt + maxdnt == 0) return
+  if (maxupt + maxdnt == 0) then 
+     call exit(0)
+  end if
   ! --- trimming
   rewind 12
   do k = 1, nlines(1)


### PR DESCRIPTION
Use standard conforming exit function instead of return, which works only for gfortran