### PR TITLE
Limit the length of the lines in codes to 132 characters

### DIFF
--- a/src/Intcts/Iopmat2.f
+++ b/src/Intcts/Iopmat2.f
@@ -734,7 +734,8 @@ c     Accumulate the I20 operator which will be multiplied by the Born ME
                outarr(i,j,-1) = infunc(i,j)*logpower*xlrs
                outarr(i,j, 0) = infunc(i,j)*((logpower*xlrs)**2/2.0_ki + pisq/12.0_ki)
                outarr(i,j, 1) = infunc(i,j)*((logpower*xlrs)**3/6.0_ki + pisq/12.0_ki*(logpower*xlrs) + zeta3/3.0_ki)
-               outarr(i,j, 2) = infunc(i,j)*((logpower*xlrs)**4/24.0_ki + pisq/24.0_ki*(logpower*xlrs)**2 + (logpower*xlrs)*zeta3/3.0_ki + pisq**2/160.0_ki)
+               outarr(i,j, 2) = infunc(i,j)*((logpower*xlrs)**4/24.0_ki + pisq/24.0_ki*(logpower*xlrs)**2 + (logpower*xlrs)*zeta3/
+     &3.0_ki + pisq**2/160.0_ki)
             endif
          enddo
       enddo

--- a/src/Intcts/include/a12carscas_functions.h
+++ b/src/Intcts/include/a12carscas_functions.h
@@ -848,8 +848,10 @@
       l115 = mylog(cone*(r1 + xa*xb))
       l116 = mylog(cone*(r1 - im*r2*r3*(-1 + xb) + xa*xb))
       l117 = mylog(cone*(r1 + im*r2*r3*(-1 + xb) + xa*xb))
-      l118 = mylog(cone*(xa - xb - 2*r2*r3*r6*(-1 + xa)*(-1 + xb*(-1 + xa + xb)) + xb*(2*xa**3*xb + xb**2 + xa*(4 + (-4 + xb)*xb**2) + xa**2*(-3 + xb*(-4 + 3*xb)))))
-      l119 = mylog(cone*(xa - xb + 2*r2*r3*r6*(-1 + xa)*(-1 + xb*(-1 + xa + xb)) + xb*(2*xa**3*xb + xb**2 + xa*(4 + (-4 + xb)*xb**2) + xa**2*(-3 + xb*(-4 + 3*xb)))))
+      l118 = mylog(cone*(xa - xb - 2*r2*r3*r6*(-1 + xa)*(-1 + xb*(-1 + xa + xb)) + xb*(2*xa**3*xb + xb**2 + xa*(4 + (-4 + xb)*xb**2)
+     & + xa**2*(-3 + xb*(-4 + 3*xb)))))
+      l119 = mylog(cone*(xa - xb + 2*r2*r3*r6*(-1 + xa)*(-1 + xb*(-1 + xa + xb)) + xb*(2*xa**3*xb + xb**2 + xa*(4 + (-4 + xb)*xb**2)
+     & + xa**2*(-3 + xb*(-4 + 3*xb)))))
       l120 = mylog((cone*(r2 - r3*r4))/(-(r3*r4) + r2*xb))
       l121 = mylog((cone*(r2/r3 + r4))/(r2*r3 + r4))
       l122 = mylog((cone*(-(r2*r6) + r3*xa))/(r3 - r2*r6))
@@ -900,7 +902,8 @@
       l167 = mylog((cone*((-2*r12)/r20 + r7 + r15*r8 + r2*r3*(xa + xb)))/(r7 + r15*r8 + r2*r3*(xa + xb)))
       l168 = mylog(cone*(r1*(r5 + xb - r5*xb - xa*xb*(-1 + xa + xb)) - xb*(r5*(-1 + xb) + xa*(1 - 2*xb + xa*(-1 + xb*(xa + xb))))))
       l169 = mylog(cone*(r1*(r5*(-1 + xb) + xb - xa*xb*(-1 + xa + xb)) - xb*(r5 - r5*xb + xa*(1 - 2*xb + xa*(-1 + xb*(xa + xb))))))
-      l170 = mylog((cone*(xa - xb + 2*r1*(-1 + xa)*(-1 + xb*(-1 + xa + xb)) + xb*(2*xa**3*xb + xb**2 + xa*(4 + (-4 + xb)*xb**2) + xa**2*(-3 + xb*(-4 + 3*xb)))))/((-1 + xb)*(1 + xb)*(xa + xb)*(-1 + xa*xb)))
+      l170 = mylog((cone*(xa - xb + 2*r1*(-1 + xa)*(-1 + xb*(-1 + xa + xb)) + xb*(2*xa**3*xb + xb**2 + xa*(4 + (-4 + xb)*xb**2) + 
+     &xa**2*(-3 + xb*(-4 + 3*xb)))))/((-1 + xb)*(1 + xb)*(xa + xb)*(-1 + xa*xb)))
       l171 = mylog((cone*(-1 + xb)*(xa + xb))/(r1 - xa))
       l172 = mylog(-((cone*r3*(-1 + xb)*(-(r2*r6) + r3*(1 + xa + xb)))/(r2*r3*r6*(-1 + xb) + 2*xa*xb - r1*(1 + xb))))
       l173 = mylog((cone*(-1 + r3)*r3*(1 + r3)*(r2*r6 + r3*(1 + xa + xb)))/(r2*r3*r6*(-1 + xb) - 2*xa*xb + r1*(1 + xb)))
@@ -1030,10 +1033,14 @@
       g2 = glog(czip,(cone*(r2 + r3*r4))/(r2 - r2*xb),cone)
       g3 = glog(czip,-((cone*(r1 + xa))/((-1 + xb)*(xa + xb))),cone)
       g4 = glog(czip,(cone*(r1 + xa*xb))/(xb - xb**2),cone)
-      g5 = glog(czip,-((cone*(r1*(r5 + xb) + xb*(xa + r5*(-1 + xa + xb) - xa*(-1 + xb)*(xa + xb))))/((1 + xa)*(-1 + xb)*xb*(xa + xb))),cone)
-      g6 = glog(czip,(cone*(r1*(r5 + xb) + xb*(xa + r5*(-1 + xa + xb) + xa*(-1 + xb)*(xa + xb))))/((-1 + xa)*(-1 + xb)*xb*(xa + xb)),cone)
-      g7 = glog(czip,(cone*(r1*(r5 - xb) + xb*(-xa + r5*(-1 + xa + xb) + xa*(-1 + xb)*(xa + xb))))/((1 + xa)*(-1 + xb)*xb*(xa + xb)),cone)
-      g8 = glog(czip,(cone*(r1*(-r5 + xb) + xb*(xa - r5*(-1 + xa + xb) + xa*(-1 + xb)*(xa + xb))))/((-1 + xa)*(-1 + xb)*xb*(xa + xb)),cone)
+      g5 = glog(czip,-((cone*(r1*(r5 + xb) + xb*(xa + r5*(-1 + xa + xb) - xa*(-1 + xb)*(xa + xb))))/((1 + xa)*(-1 + xb)*xb*(xa + xb)
+     &)),cone)
+      g6 = glog(czip,(cone*(r1*(r5 + xb) + xb*(xa + r5*(-1 + xa + xb) + xa*(-1 + xb)*(xa + xb))))/((-1 + xa)*(-1 + xb)*xb*(xa + xb))
+     &,cone)
+      g7 = glog(czip,(cone*(r1*(r5 - xb) + xb*(-xa + r5*(-1 + xa + xb) + xa*(-1 + xb)*(xa + xb))))/((1 + xa)*(-1 + xb)*xb*(xa + xb))
+     &,cone)
+      g8 = glog(czip,(cone*(r1*(-r5 + xb) + xb*(xa - r5*(-1 + xa + xb) + xa*(-1 + xb)*(xa + xb))))/((-1 + xa)*(-1 + xb)*xb*(xa + xb)
+     &),cone)
       g9 = glog((cone*(r2 - im*r3))/(r2 - r2*xb),czip,cone)
       g10 = glog((cone*(r2 - im*r3))/(r2 - r2*xb),(cone*(1 + xb))/(1 - xb),cone)
       g11 = glog((cone*(r2 - im*r3))/(r2 - r2*xb),(cone*(1 - xa))/(xa*(-1 + xb)),cone)
@@ -1111,33 +1118,51 @@
       g83 = glog((cone*(r1 - xa*xb))/(xb - xa*xb),(cone*(1 + xa))/(-1 + xa),cone)
       g84 = glog((cone*(r1 - xa*xb))/(xb - xa*xb),(cone*xa*(1 + xb))/((-1 + xa)*xb),cone)
       g85 = glog((cone*((-im)*r1 + r2*r3*(-1 + xb) - im*xa*xb))/((r2 + im*r3)*r3*(-1 + xb)),cone,cone)
-      g86 = glog((cone*((-im)*r1 + r2*r3*(-1 + xb) - im*xa*xb))/((r2 + im*r3)*r3*(-1 + xb)),-((cone*(r1 + xa))/((-1 + xb)*(xa + xb))),cone)
+      g86 = glog((cone*((-im)*r1 + r2*r3*(-1 + xb) - im*xa*xb))/((r2 + im*r3)*r3*(-1 + xb)),-((cone*(r1 + xa))/((-1 + xb)*(xa + xb))
+     &),cone)
       g87 = glog((cone*((-im)*r1 + r2*r3*(-1 + xb) - im*xa*xb))/((r2 + im*r3)*r3*(-1 + xb)),(cone*(r1 + xa*xb))/(xb - xb**2),cone)
-      g88 = glog((cone*((-im)*r1 + r2*r3*(-1 + xb) - im*xa*xb))/((r2 + im*r3)*r3*(-1 + xb)),-((cone*(r1*(r5 + xb) + xb*(xa + r5*(-1 + xa + xb) - xa*(-1 + xb)*(xa + xb))))/((1 + xa)*(-1 + xb)*xb*(xa + xb))),cone)
-      g89 = glog((cone*((-im)*r1 + r2*r3*(-1 + xb) - im*xa*xb))/((r2 + im*r3)*r3*(-1 + xb)),(cone*(r1*(r5 + xb) + xb*(xa + r5*(-1 + xa + xb) + xa*(-1 + xb)*(xa + xb))))/((-1 + xa)*(-1 + xb)*xb*(xa + xb)),cone)
-      g90 = glog((cone*((-im)*r1 + r2*r3*(-1 + xb) - im*xa*xb))/((r2 + im*r3)*r3*(-1 + xb)),(cone*(r1*(r5 - xb) + xb*(-xa + r5*(-1 + xa + xb) + xa*(-1 + xb)*(xa + xb))))/((1 + xa)*(-1 + xb)*xb*(xa + xb)),cone)
-      g91 = glog((cone*((-im)*r1 + r2*r3*(-1 + xb) - im*xa*xb))/((r2 + im*r3)*r3*(-1 + xb)),(cone*(r1*(-r5 + xb) + xb*(xa - r5*(-1 + xa + xb) + xa*(-1 + xb)*(xa + xb))))/((-1 + xa)*(-1 + xb)*xb*(xa + xb)),cone)
+      g88 = glog((cone*((-im)*r1 + r2*r3*(-1 + xb) - im*xa*xb))/((r2 + im*r3)*r3*(-1 + xb)),-((cone*(r1*(r5 + xb) + xb*(xa + r5*(-1 
+     &+ xa + xb) - xa*(-1 + xb)*(xa + xb))))/((1 + xa)*(-1 + xb)*xb*(xa + xb))),cone)
+      g89 = glog((cone*((-im)*r1 + r2*r3*(-1 + xb) - im*xa*xb))/((r2 + im*r3)*r3*(-1 + xb)),(cone*(r1*(r5 + xb) + xb*(xa + r5*(-1 + 
+     &xa + xb) + xa*(-1 + xb)*(xa + xb))))/((-1 + xa)*(-1 + xb)*xb*(xa + xb)),cone)
+      g90 = glog((cone*((-im)*r1 + r2*r3*(-1 + xb) - im*xa*xb))/((r2 + im*r3)*r3*(-1 + xb)),(cone*(r1*(r5 - xb) + xb*(-xa + r5*(-1 +
+     & xa + xb) + xa*(-1 + xb)*(xa + xb))))/((1 + xa)*(-1 + xb)*xb*(xa + xb)),cone)
+      g91 = glog((cone*((-im)*r1 + r2*r3*(-1 + xb) - im*xa*xb))/((r2 + im*r3)*r3*(-1 + xb)),(cone*(r1*(-r5 + xb) + xb*(xa - r5*(-1 +
+     & xa + xb) + xa*(-1 + xb)*(xa + xb))))/((-1 + xa)*(-1 + xb)*xb*(xa + xb)),cone)
       g92 = glog((cone*(im*r1 + r2*r3*(-1 + xb) + im*xa*xb))/((r2 - im*r3)*r3*(-1 + r3**2)),cone,cone)
-      g93 = glog((cone*(im*r1 + r2*r3*(-1 + xb) + im*xa*xb))/((r2 - im*r3)*r3*(-1 + r3**2)),-((cone*(r1 + xa))/((-1 + xb)*(xa + xb))),cone)
+      g93 = glog((cone*(im*r1 + r2*r3*(-1 + xb) + im*xa*xb))/((r2 - im*r3)*r3*(-1 + r3**2)),-((cone*(r1 + xa))/((-1 + xb)*(xa + xb))
+     &),cone)
       g94 = glog((cone*(im*r1 + r2*r3*(-1 + xb) + im*xa*xb))/((r2 - im*r3)*r3*(-1 + r3**2)),(cone*(r1 + xa*xb))/(xb - xb**2),cone)
-      g95 = glog((cone*(im*r1 + r2*r3*(-1 + xb) + im*xa*xb))/((r2 - im*r3)*r3*(-1 + r3**2)),-((cone*(r1*(r5 + xb) + xb*(xa + r5*(-1 + xa + xb) - xa*(-1 + xb)*(xa + xb))))/((1 + xa)*(-1 + xb)*xb*(xa + xb))),cone)
-      g96 = glog((cone*(im*r1 + r2*r3*(-1 + xb) + im*xa*xb))/((r2 - im*r3)*r3*(-1 + r3**2)),(cone*(r1*(r5 + xb) + xb*(xa + r5*(-1 + xa + xb) + xa*(-1 + xb)*(xa + xb))))/((-1 + xa)*(-1 + xb)*xb*(xa + xb)),cone)
-      g97 = glog((cone*(im*r1 + r2*r3*(-1 + xb) + im*xa*xb))/((r2 - im*r3)*r3*(-1 + r3**2)),(cone*(r1*(r5 - xb) + xb*(-xa + r5*(-1 + xa + xb) + xa*(-1 + xb)*(xa + xb))))/((1 + xa)*(-1 + xb)*xb*(xa + xb)),cone)
-      g98 = glog((cone*(im*r1 + r2*r3*(-1 + xb) + im*xa*xb))/((r2 - im*r3)*r3*(-1 + r3**2)),(cone*(r1*(-r5 + xb) + xb*(xa - r5*(-1 + xa + xb) + xa*(-1 + xb)*(xa + xb))))/((-1 + xa)*(-1 + xb)*xb*(xa + xb)),cone)
+      g95 = glog((cone*(im*r1 + r2*r3*(-1 + xb) + im*xa*xb))/((r2 - im*r3)*r3*(-1 + r3**2)),-((cone*(r1*(r5 + xb) + xb*(xa + r5*(-1 
+     &+ xa + xb) - xa*(-1 + xb)*(xa + xb))))/((1 + xa)*(-1 + xb)*xb*(xa + xb))),cone)
+      g96 = glog((cone*(im*r1 + r2*r3*(-1 + xb) + im*xa*xb))/((r2 - im*r3)*r3*(-1 + r3**2)),(cone*(r1*(r5 + xb) + xb*(xa + r5*(-1 + 
+     &xa + xb) + xa*(-1 + xb)*(xa + xb))))/((-1 + xa)*(-1 + xb)*xb*(xa + xb)),cone)
+      g97 = glog((cone*(im*r1 + r2*r3*(-1 + xb) + im*xa*xb))/((r2 - im*r3)*r3*(-1 + r3**2)),(cone*(r1*(r5 - xb) + xb*(-xa + r5*(-1 +
+     & xa + xb) + xa*(-1 + xb)*(xa + xb))))/((1 + xa)*(-1 + xb)*xb*(xa + xb)),cone)
+      g98 = glog((cone*(im*r1 + r2*r3*(-1 + xb) + im*xa*xb))/((r2 - im*r3)*r3*(-1 + r3**2)),(cone*(r1*(-r5 + xb) + xb*(xa - r5*(-1 +
+     & xa + xb) + xa*(-1 + xb)*(xa + xb))))/((-1 + xa)*(-1 + xb)*xb*(xa + xb)),cone)
       g99 = glog(-((cone*(r1 + xa))/((-1 + xb)*(xa + xb))),cone,cone)
       g100 = glog(-((cone*(r1 + xa))/((-1 + xb)*(xa + xb))),-((cone*(r1 + xa))/((-1 + xb)*(xa + xb))),cone)
       g101 = glog(-((cone*(r1 + xa))/((-1 + xb)*(xa + xb))),(cone*(r1 + xa*xb))/(xb - xb**2),cone)
-      g102 = glog(-((cone*(r1 + xa))/((-1 + xb)*(xa + xb))),-((cone*(r1*(r5 + xb) + xb*(xa + r5*(-1 + xa + xb) - xa*(-1 + xb)*(xa + xb))))/((1 + xa)*(-1 + xb)*xb*(xa + xb))),cone)
-      g103 = glog(-((cone*(r1 + xa))/((-1 + xb)*(xa + xb))),(cone*(r1*(r5 + xb) + xb*(xa + r5*(-1 + xa + xb) + xa*(-1 + xb)*(xa + xb))))/((-1 + xa)*(-1 + xb)*xb*(xa + xb)),cone)
-      g104 = glog(-((cone*(r1 + xa))/((-1 + xb)*(xa + xb))),(cone*(r1*(r5 - xb) + xb*(-xa + r5*(-1 + xa + xb) + xa*(-1 + xb)*(xa + xb))))/((1 + xa)*(-1 + xb)*xb*(xa + xb)),cone)
-      g105 = glog(-((cone*(r1 + xa))/((-1 + xb)*(xa + xb))),(cone*(r1*(-r5 + xb) + xb*(xa - r5*(-1 + xa + xb) + xa*(-1 + xb)*(xa + xb))))/((-1 + xa)*(-1 + xb)*xb*(xa + xb)),cone)
+      g102 = glog(-((cone*(r1 + xa))/((-1 + xb)*(xa + xb))),-((cone*(r1*(r5 + xb) + xb*(xa + r5*(-1 + xa + xb) - xa*(-1 + xb)*(xa + 
+     &xb))))/((1 + xa)*(-1 + xb)*xb*(xa + xb))),cone)
+      g103 = glog(-((cone*(r1 + xa))/((-1 + xb)*(xa + xb))),(cone*(r1*(r5 + xb) + xb*(xa + r5*(-1 + xa + xb) + xa*(-1 + xb)*(xa + 
+     &xb))))/((-1 + xa)*(-1 + xb)*xb*(xa + xb)),cone)
+      g104 = glog(-((cone*(r1 + xa))/((-1 + xb)*(xa + xb))),(cone*(r1*(r5 - xb) + xb*(-xa + r5*(-1 + xa + xb) + xa*(-1 + xb)*(xa + 
+     &xb))))/((1 + xa)*(-1 + xb)*xb*(xa + xb)),cone)
+      g105 = glog(-((cone*(r1 + xa))/((-1 + xb)*(xa + xb))),(cone*(r1*(-r5 + xb) + xb*(xa - r5*(-1 + xa + xb) + xa*(-1 + xb)*(xa + 
+     &xb))))/((-1 + xa)*(-1 + xb)*xb*(xa + xb)),cone)
       g106 = glog((-2*cone*(r1 + xa))/((xa + xb)*(-1 + xb**2)),cone,cone)
       g107 = glog((-2*cone*(r1 + xa))/((xa + xb)*(-1 + xb**2)),-((cone*(r1 + xa))/((-1 + xb)*(xa + xb))),cone)
       g108 = glog((-2*cone*(r1 + xa))/((xa + xb)*(-1 + xb**2)),(cone*(r1 + xa*xb))/(xb - xb**2),cone)
-      g109 = glog((-2*cone*(r1 + xa))/((xa + xb)*(-1 + xb**2)),-((cone*(r1*(r5 + xb) + xb*(xa + r5*(-1 + xa + xb) - xa*(-1 + xb)*(xa + xb))))/((1 + xa)*(-1 + xb)*xb*(xa + xb))),cone)
-      g110 = glog((-2*cone*(r1 + xa))/((xa + xb)*(-1 + xb**2)),(cone*(r1*(r5 + xb) + xb*(xa + r5*(-1 + xa + xb) + xa*(-1 + xb)*(xa + xb))))/((-1 + xa)*(-1 + xb)*xb*(xa + xb)),cone)
-      g111 = glog((-2*cone*(r1 + xa))/((xa + xb)*(-1 + xb**2)),(cone*(r1*(r5 - xb) + xb*(-xa + r5*(-1 + xa + xb) + xa*(-1 + xb)*(xa + xb))))/((1 + xa)*(-1 + xb)*xb*(xa + xb)),cone)
-      g112 = glog((-2*cone*(r1 + xa))/((xa + xb)*(-1 + xb**2)),(cone*(r1*(-r5 + xb) + xb*(xa - r5*(-1 + xa + xb) + xa*(-1 + xb)*(xa + xb))))/((-1 + xa)*(-1 + xb)*xb*(xa + xb)),cone)
+      g109 = glog((-2*cone*(r1 + xa))/((xa + xb)*(-1 + xb**2)),-((cone*(r1*(r5 + xb) + xb*(xa + r5*(-1 + xa + xb) - xa*(-1 + xb)*(
+     &xa + xb))))/((1 + xa)*(-1 + xb)*xb*(xa + xb))),cone)
+      g110 = glog((-2*cone*(r1 + xa))/((xa + xb)*(-1 + xb**2)),(cone*(r1*(r5 + xb) + xb*(xa + r5*(-1 + xa + xb) + xa*(-1 + xb)*(xa +
+     & xb))))/((-1 + xa)*(-1 + xb)*xb*(xa + xb)),cone)
+      g111 = glog((-2*cone*(r1 + xa))/((xa + xb)*(-1 + xb**2)),(cone*(r1*(r5 - xb) + xb*(-xa + r5*(-1 + xa + xb) + xa*(-1 + xb)*(xa 
+     &+ xb))))/((1 + xa)*(-1 + xb)*xb*(xa + xb)),cone)
+      g112 = glog((-2*cone*(r1 + xa))/((xa + xb)*(-1 + xb**2)),(cone*(r1*(-r5 + xb) + xb*(xa - r5*(-1 + xa + xb) + xa*(-1 + xb)*(xa 
+     &+ xb))))/((-1 + xa)*(-1 + xb)*xb*(xa + xb)),cone)
       g113 = glog(-((cone*(r1 + xb))/(xb*(-2 + xa + xb))),cone,cone)
       g114 = glog((cone*(r1 + xa*xb))/((-1 + xa)*xb),czip,cone)
       g115 = glog((cone*(r1 + xa*xb))/((-1 + xa)*xb),cone,cone)
@@ -1148,82 +1173,135 @@
       g120 = glog((cone*(r1 + xa*xb))/(xb - xb**2),cone,cone)
       g121 = glog((cone*(r1 + xa*xb))/(xb - xb**2),-((cone*(r1 + xa))/((-1 + xb)*(xa + xb))),cone)
       g122 = glog((cone*(r1 + xa*xb))/(xb - xb**2),(cone*(r1 + xa*xb))/(xb - xb**2),cone)
-      g123 = glog((cone*(r1 + xa*xb))/(xb - xb**2),-((cone*(r1*(r5 + xb) + xb*(xa + r5*(-1 + xa + xb) - xa*(-1 + xb)*(xa + xb))))/((1 + xa)*(-1 + xb)*xb*(xa + xb))),cone)
-      g124 = glog((cone*(r1 + xa*xb))/(xb - xb**2),(cone*(r1*(r5 + xb) + xb*(xa + r5*(-1 + xa + xb) + xa*(-1 + xb)*(xa + xb))))/((-1 + xa)*(-1 + xb)*xb*(xa + xb)),cone)
-      g125 = glog((cone*(r1 + xa*xb))/(xb - xb**2),(cone*(r1*(r5 - xb) + xb*(-xa + r5*(-1 + xa + xb) + xa*(-1 + xb)*(xa + xb))))/((1 + xa)*(-1 + xb)*xb*(xa + xb)),cone)
-      g126 = glog((cone*(r1 + xa*xb))/(xb - xb**2),(cone*(r1*(-r5 + xb) + xb*(xa - r5*(-1 + xa + xb) + xa*(-1 + xb)*(xa + xb))))/((-1 + xa)*(-1 + xb)*xb*(xa + xb)),cone)
+      g123 = glog((cone*(r1 + xa*xb))/(xb - xb**2),-((cone*(r1*(r5 + xb) + xb*(xa + r5*(-1 + xa + xb) - xa*(-1 + xb)*(xa + xb))))/((
+     &1 + xa)*(-1 + xb)*xb*(xa + xb))),cone)
+      g124 = glog((cone*(r1 + xa*xb))/(xb - xb**2),(cone*(r1*(r5 + xb) + xb*(xa + r5*(-1 + xa + xb) + xa*(-1 + xb)*(xa + xb))))/((-
+     &1 + xa)*(-1 + xb)*xb*(xa + xb)),cone)
+      g125 = glog((cone*(r1 + xa*xb))/(xb - xb**2),(cone*(r1*(r5 - xb) + xb*(-xa + r5*(-1 + xa + xb) + xa*(-1 + xb)*(xa + xb))))/((
+     &1 + xa)*(-1 + xb)*xb*(xa + xb)),cone)
+      g126 = glog((cone*(r1 + xa*xb))/(xb - xb**2),(cone*(r1*(-r5 + xb) + xb*(xa - r5*(-1 + xa + xb) + xa*(-1 + xb)*(xa + xb))))/((-
+     &1 + xa)*(-1 + xb)*xb*(xa + xb)),cone)
       g127 = glog((-2*cone*(r1 + xa*xb))/(-1 + xb**2),cone,cone)
       g128 = glog((-2*cone*(r1 + xa*xb))/(-1 + xb**2),-((cone*(r1 + xa))/((-1 + xb)*(xa + xb))),cone)
       g129 = glog((-2*cone*(r1 + xa*xb))/(-1 + xb**2),(cone*(r1 + xa*xb))/(xb - xb**2),cone)
-      g130 = glog((-2*cone*(r1 + xa*xb))/(-1 + xb**2),-((cone*(r1*(r5 + xb) + xb*(xa + r5*(-1 + xa + xb) - xa*(-1 + xb)*(xa + xb))))/((1 + xa)*(-1 + xb)*xb*(xa + xb))),cone)
-      g131 = glog((-2*cone*(r1 + xa*xb))/(-1 + xb**2),(cone*(r1*(r5 + xb) + xb*(xa + r5*(-1 + xa + xb) + xa*(-1 + xb)*(xa + xb))))/((-1 + xa)*(-1 + xb)*xb*(xa + xb)),cone)
-      g132 = glog((-2*cone*(r1 + xa*xb))/(-1 + xb**2),(cone*(r1*(r5 - xb) + xb*(-xa + r5*(-1 + xa + xb) + xa*(-1 + xb)*(xa + xb))))/((1 + xa)*(-1 + xb)*xb*(xa + xb)),cone)
-      g133 = glog((-2*cone*(r1 + xa*xb))/(-1 + xb**2),(cone*(r1*(-r5 + xb) + xb*(xa - r5*(-1 + xa + xb) + xa*(-1 + xb)*(xa + xb))))/((-1 + xa)*(-1 + xb)*xb*(xa + xb)),cone)
+      g130 = glog((-2*cone*(r1 + xa*xb))/(-1 + xb**2),-((cone*(r1*(r5 + xb) + xb*(xa + r5*(-1 + xa + xb) - xa*(-1 + xb)*(xa + xb))))
+     &/((1 + xa)*(-1 + xb)*xb*(xa + xb))),cone)
+      g131 = glog((-2*cone*(r1 + xa*xb))/(-1 + xb**2),(cone*(r1*(r5 + xb) + xb*(xa + r5*(-1 + xa + xb) + xa*(-1 + xb)*(xa + xb))))/(
+     &(-1 + xa)*(-1 + xb)*xb*(xa + xb)),cone)
+      g132 = glog((-2*cone*(r1 + xa*xb))/(-1 + xb**2),(cone*(r1*(r5 - xb) + xb*(-xa + r5*(-1 + xa + xb) + xa*(-1 + xb)*(xa + xb))))/
+     &((1 + xa)*(-1 + xb)*xb*(xa + xb)),cone)
+      g133 = glog((-2*cone*(r1 + xa*xb))/(-1 + xb**2),(cone*(r1*(-r5 + xb) + xb*(xa - r5*(-1 + xa + xb) + xa*(-1 + xb)*(xa + xb))))/
+     &((-1 + xa)*(-1 + xb)*xb*(xa + xb)),cone)
       g134 = glog((cone*(r1 - xa))/(r1 - xb*(-1 + xa + xb)),cone,cone)
       g135 = glog((cone*(r1 - xa))/(r1 - xb*(-1 + xa + xb)),(cone*(r1 - xa))/(r1 - xb*(-1 + xa + xb)),cone)
       g136 = glog((cone*(r1 - xa))/(r1 - xb*(-1 + xa + xb)),(cone*(r1 - xa*xb))/(r1 - xb*(-1 + xa + xb)),cone)
-      g137 = glog((cone*(r1 - xa))/(r1 - xb*(-1 + xa + xb)),(cone*(-(r1*(1 + xa)) - r2*r3*r4*(-1 + xb) + xa*xb*(xa + xb)))/((1 + xa)*(-r1 + xb*(-1 + xa + xb))),cone)
-      g138 = glog((cone*(r1 - xa))/(r1 - xb*(-1 + xa + xb)),(cone*(-(r1*(1 + xa)) + r2*r3*r4*(-1 + xb) + xa*xb*(xa + xb)))/((1 + xa)*(-r1 + xb*(-1 + xa + xb))),cone)
-      g139 = glog((cone*(r1 - xa))/(r1 - xb*(-1 + xa + xb)),(cone*(r1 - r1*xa - r2*r3*r4*(-1 + xb) + xa*xb*(-2 + xa + xb)))/((-1 + xa)*(-r1 + xb*(-1 + xa + xb))),cone)
-      g140 = glog((cone*(r1 - xa))/(r1 - xb*(-1 + xa + xb)),(cone*(r1 - r1*xa + r2*r3*r4*(-1 + xb) + xa*xb*(-2 + xa + xb)))/((-1 + xa)*(-r1 + xb*(-1 + xa + xb))),cone)
+      g137 = glog((cone*(r1 - xa))/(r1 - xb*(-1 + xa + xb)),(cone*(-(r1*(1 + xa)) - r2*r3*r4*(-1 + xb) + xa*xb*(xa + xb)))/((1 + xa)
+     &*(-r1 + xb*(-1 + xa + xb))),cone)
+      g138 = glog((cone*(r1 - xa))/(r1 - xb*(-1 + xa + xb)),(cone*(-(r1*(1 + xa)) + r2*r3*r4*(-1 + xb) + xa*xb*(xa + xb)))/((1 + xa)
+     &*(-r1 + xb*(-1 + xa + xb))),cone)
+      g139 = glog((cone*(r1 - xa))/(r1 - xb*(-1 + xa + xb)),(cone*(r1 - r1*xa - r2*r3*r4*(-1 + xb) + xa*xb*(-2 + xa + xb)))/((-1 + 
+     &xa)*(-r1 + xb*(-1 + xa + xb))),cone)
+      g140 = glog((cone*(r1 - xa))/(r1 - xb*(-1 + xa + xb)),(cone*(r1 - r1*xa + r2*r3*r4*(-1 + xb) + xa*xb*(-2 + xa + xb)))/((-1 + 
+     &xa)*(-r1 + xb*(-1 + xa + xb))),cone)
       g141 = glog((cone*(r1 - xb))/(r1 - xb*(-1 + xa + xb)),cone,cone)
       g142 = glog((cone*(r1 - xa*xb))/(r1 - xb*(-1 + xa + xb)),cone,cone)
       g143 = glog((cone*(r1 - xa*xb))/(r1 - xb*(-1 + xa + xb)),(cone*(r1 - xa))/(r1 - xb*(-1 + xa + xb)),cone)
       g144 = glog((cone*(r1 - xa*xb))/(r1 - xb*(-1 + xa + xb)),(cone*(r1 - xa*xb))/(r1 - xb*(-1 + xa + xb)),cone)
-      g145 = glog((cone*(r1 - xa*xb))/(r1 - xb*(-1 + xa + xb)),(cone*(-(r1*(1 + xa)) - r2*r3*r4*(-1 + xb) + xa*xb*(xa + xb)))/((1 + xa)*(-r1 + xb*(-1 + xa + xb))),cone)
-      g146 = glog((cone*(r1 - xa*xb))/(r1 - xb*(-1 + xa + xb)),(cone*(-(r1*(1 + xa)) + r2*r3*r4*(-1 + xb) + xa*xb*(xa + xb)))/((1 + xa)*(-r1 + xb*(-1 + xa + xb))),cone)
-      g147 = glog((cone*(r1 - xa*xb))/(r1 - xb*(-1 + xa + xb)),(cone*(r1 - r1*xa - r2*r3*r4*(-1 + xb) + xa*xb*(-2 + xa + xb)))/((-1 + xa)*(-r1 + xb*(-1 + xa + xb))),cone)
-      g148 = glog((cone*(r1 - xa*xb))/(r1 - xb*(-1 + xa + xb)),(cone*(r1 - r1*xa + r2*r3*r4*(-1 + xb) + xa*xb*(-2 + xa + xb)))/((-1 + xa)*(-r1 + xb*(-1 + xa + xb))),cone)
+      g145 = glog((cone*(r1 - xa*xb))/(r1 - xb*(-1 + xa + xb)),(cone*(-(r1*(1 + xa)) - r2*r3*r4*(-1 + xb) + xa*xb*(xa + xb)))/((1 + 
+     &xa)*(-r1 + xb*(-1 + xa + xb))),cone)
+      g146 = glog((cone*(r1 - xa*xb))/(r1 - xb*(-1 + xa + xb)),(cone*(-(r1*(1 + xa)) + r2*r3*r4*(-1 + xb) + xa*xb*(xa + xb)))/((1 + 
+     &xa)*(-r1 + xb*(-1 + xa + xb))),cone)
+      g147 = glog((cone*(r1 - xa*xb))/(r1 - xb*(-1 + xa + xb)),(cone*(r1 - r1*xa - r2*r3*r4*(-1 + xb) + xa*xb*(-2 + xa + xb)))/((-1 
+     &+ xa)*(-r1 + xb*(-1 + xa + xb))),cone)
+      g148 = glog((cone*(r1 - xa*xb))/(r1 - xb*(-1 + xa + xb)),(cone*(r1 - r1*xa + r2*r3*r4*(-1 + xb) + xa*xb*(-2 + xa + xb)))/((-1 
+     &+ xa)*(-r1 + xb*(-1 + xa + xb))),cone)
       g149 = glog((cone*(r1 - im*r2*r3*(-1 + xb) - xa*xb))/(r1 - xb*(-1 + xa + xb)),cone,cone)
       g150 = glog((cone*(r1 - im*r2*r3*(-1 + xb) - xa*xb))/(r1 - xb*(-1 + xa + xb)),(cone*(r1 - xa))/(r1 - xb*(-1 + xa + xb)),cone)
-      g151 = glog((cone*(r1 - im*r2*r3*(-1 + xb) - xa*xb))/(r1 - xb*(-1 + xa + xb)),(cone*(r1 - xa*xb))/(r1 - xb*(-1 + xa + xb)),cone)
-      g152 = glog((cone*(r1 - im*r2*r3*(-1 + xb) - xa*xb))/(r1 - xb*(-1 + xa + xb)),(cone*(-(r1*(1 + xa)) - r2*r3*r4*(-1 + xb) + xa*xb*(xa + xb)))/((1 + xa)*(-r1 + xb*(-1 + xa + xb))),cone)
-      g153 = glog((cone*(r1 - im*r2*r3*(-1 + xb) - xa*xb))/(r1 - xb*(-1 + xa + xb)),(cone*(-(r1*(1 + xa)) + r2*r3*r4*(-1 + xb) + xa*xb*(xa + xb)))/((1 + xa)*(-r1 + xb*(-1 + xa + xb))),cone)
-      g154 = glog((cone*(r1 - im*r2*r3*(-1 + xb) - xa*xb))/(r1 - xb*(-1 + xa + xb)),(cone*(r1 - r1*xa - r2*r3*r4*(-1 + xb) + xa*xb*(-2 + xa + xb)))/((-1 + xa)*(-r1 + xb*(-1 + xa + xb))),cone)
-      g155 = glog((cone*(r1 - im*r2*r3*(-1 + xb) - xa*xb))/(r1 - xb*(-1 + xa + xb)),(cone*(r1 - r1*xa + r2*r3*r4*(-1 + xb) + xa*xb*(-2 + xa + xb)))/((-1 + xa)*(-r1 + xb*(-1 + xa + xb))),cone)
+      g151 = glog((cone*(r1 - im*r2*r3*(-1 + xb) - xa*xb))/(r1 - xb*(-1 + xa + xb)),(cone*(r1 - xa*xb))/(r1 - xb*(-1 + xa + xb)),
+     &cone)
+      g152 = glog((cone*(r1 - im*r2*r3*(-1 + xb) - xa*xb))/(r1 - xb*(-1 + xa + xb)),(cone*(-(r1*(1 + xa)) - r2*r3*r4*(-1 + xb) + 
+     &xa*xb*(xa + xb)))/((1 + xa)*(-r1 + xb*(-1 + xa + xb))),cone)
+      g153 = glog((cone*(r1 - im*r2*r3*(-1 + xb) - xa*xb))/(r1 - xb*(-1 + xa + xb)),(cone*(-(r1*(1 + xa)) + r2*r3*r4*(-1 + xb) + 
+     &xa*xb*(xa + xb)))/((1 + xa)*(-r1 + xb*(-1 + xa + xb))),cone)
+      g154 = glog((cone*(r1 - im*r2*r3*(-1 + xb) - xa*xb))/(r1 - xb*(-1 + xa + xb)),(cone*(r1 - r1*xa - r2*r3*r4*(-1 + xb) + xa*xb*(
+     &-2 + xa + xb)))/((-1 + xa)*(-r1 + xb*(-1 + xa + xb))),cone)
+      g155 = glog((cone*(r1 - im*r2*r3*(-1 + xb) - xa*xb))/(r1 - xb*(-1 + xa + xb)),(cone*(r1 - r1*xa + r2*r3*r4*(-1 + xb) + xa*xb*(
+     &-2 + xa + xb)))/((-1 + xa)*(-r1 + xb*(-1 + xa + xb))),cone)
       g156 = glog((cone*(r1 + im*r2*r3*(-1 + xb) - xa*xb))/(r1 - xb*(-1 + xa + xb)),cone,cone)
       g157 = glog((cone*(r1 + im*r2*r3*(-1 + xb) - xa*xb))/(r1 - xb*(-1 + xa + xb)),(cone*(r1 - xa))/(r1 - xb*(-1 + xa + xb)),cone)
-      g158 = glog((cone*(r1 + im*r2*r3*(-1 + xb) - xa*xb))/(r1 - xb*(-1 + xa + xb)),(cone*(r1 - xa*xb))/(r1 - xb*(-1 + xa + xb)),cone)
-      g159 = glog((cone*(r1 + im*r2*r3*(-1 + xb) - xa*xb))/(r1 - xb*(-1 + xa + xb)),(cone*(-(r1*(1 + xa)) - r2*r3*r4*(-1 + xb) + xa*xb*(xa + xb)))/((1 + xa)*(-r1 + xb*(-1 + xa + xb))),cone)
-      g160 = glog((cone*(r1 + im*r2*r3*(-1 + xb) - xa*xb))/(r1 - xb*(-1 + xa + xb)),(cone*(-(r1*(1 + xa)) + r2*r3*r4*(-1 + xb) + xa*xb*(xa + xb)))/((1 + xa)*(-r1 + xb*(-1 + xa + xb))),cone)
-      g161 = glog((cone*(r1 + im*r2*r3*(-1 + xb) - xa*xb))/(r1 - xb*(-1 + xa + xb)),(cone*(r1 - r1*xa - r2*r3*r4*(-1 + xb) + xa*xb*(-2 + xa + xb)))/((-1 + xa)*(-r1 + xb*(-1 + xa + xb))),cone)
-      g162 = glog((cone*(r1 + im*r2*r3*(-1 + xb) - xa*xb))/(r1 - xb*(-1 + xa + xb)),(cone*(r1 - r1*xa + r2*r3*r4*(-1 + xb) + xa*xb*(-2 + xa + xb)))/((-1 + xa)*(-r1 + xb*(-1 + xa + xb))),cone)
+      g158 = glog((cone*(r1 + im*r2*r3*(-1 + xb) - xa*xb))/(r1 - xb*(-1 + xa + xb)),(cone*(r1 - xa*xb))/(r1 - xb*(-1 + xa + xb)),
+     &cone)
+      g159 = glog((cone*(r1 + im*r2*r3*(-1 + xb) - xa*xb))/(r1 - xb*(-1 + xa + xb)),(cone*(-(r1*(1 + xa)) - r2*r3*r4*(-1 + xb) + 
+     &xa*xb*(xa + xb)))/((1 + xa)*(-r1 + xb*(-1 + xa + xb))),cone)
+      g160 = glog((cone*(r1 + im*r2*r3*(-1 + xb) - xa*xb))/(r1 - xb*(-1 + xa + xb)),(cone*(-(r1*(1 + xa)) + r2*r3*r4*(-1 + xb) + 
+     &xa*xb*(xa + xb)))/((1 + xa)*(-r1 + xb*(-1 + xa + xb))),cone)
+      g161 = glog((cone*(r1 + im*r2*r3*(-1 + xb) - xa*xb))/(r1 - xb*(-1 + xa + xb)),(cone*(r1 - r1*xa - r2*r3*r4*(-1 + xb) + xa*xb*(
+     &-2 + xa + xb)))/((-1 + xa)*(-r1 + xb*(-1 + xa + xb))),cone)
+      g162 = glog((cone*(r1 + im*r2*r3*(-1 + xb) - xa*xb))/(r1 - xb*(-1 + xa + xb)),(cone*(r1 - r1*xa + r2*r3*r4*(-1 + xb) + xa*xb*(
+     &-2 + xa + xb)))/((-1 + xa)*(-r1 + xb*(-1 + xa + xb))),cone)
       g163 = glog((cone*(r1 - r2*r3*r6))/(r1 - xb*(-1 + xa + xb)),cone,cone)
       g164 = glog((cone*(r1 - r2*r3*r6))/(r1 - xb*(-1 + xa + xb)),(cone*(r1 - xa))/(r1 - xb*(-1 + xa + xb)),cone)
       g165 = glog((cone*(r1 - r2*r3*r6))/(r1 - xb*(-1 + xa + xb)),(cone*(r1 - xa*xb))/(r1 - xb*(-1 + xa + xb)),cone)
-      g166 = glog((cone*(r1 - r2*r3*r6))/(r1 - xb*(-1 + xa + xb)),(cone*(-(r1*(1 + xa)) - r2*r3*r4*(-1 + xb) + xa*xb*(xa + xb)))/((1 + xa)*(-r1 + xb*(-1 + xa + xb))),cone)
-      g167 = glog((cone*(r1 - r2*r3*r6))/(r1 - xb*(-1 + xa + xb)),(cone*(-(r1*(1 + xa)) + r2*r3*r4*(-1 + xb) + xa*xb*(xa + xb)))/((1 + xa)*(-r1 + xb*(-1 + xa + xb))),cone)
-      g168 = glog((cone*(r1 - r2*r3*r6))/(r1 - xb*(-1 + xa + xb)),(cone*(r1 - r1*xa - r2*r3*r4*(-1 + xb) + xa*xb*(-2 + xa + xb)))/((-1 + xa)*(-r1 + xb*(-1 + xa + xb))),cone)
-      g169 = glog((cone*(r1 - r2*r3*r6))/(r1 - xb*(-1 + xa + xb)),(cone*(r1 - r1*xa + r2*r3*r4*(-1 + xb) + xa*xb*(-2 + xa + xb)))/((-1 + xa)*(-r1 + xb*(-1 + xa + xb))),cone)
+      g166 = glog((cone*(r1 - r2*r3*r6))/(r1 - xb*(-1 + xa + xb)),(cone*(-(r1*(1 + xa)) - r2*r3*r4*(-1 + xb) + xa*xb*(xa + xb)))/((
+     &1 + xa)*(-r1 + xb*(-1 + xa + xb))),cone)
+      g167 = glog((cone*(r1 - r2*r3*r6))/(r1 - xb*(-1 + xa + xb)),(cone*(-(r1*(1 + xa)) + r2*r3*r4*(-1 + xb) + xa*xb*(xa + xb)))/((
+     &1 + xa)*(-r1 + xb*(-1 + xa + xb))),cone)
+      g168 = glog((cone*(r1 - r2*r3*r6))/(r1 - xb*(-1 + xa + xb)),(cone*(r1 - r1*xa - r2*r3*r4*(-1 + xb) + xa*xb*(-2 + xa + xb)))/((
+     &-1 + xa)*(-r1 + xb*(-1 + xa + xb))),cone)
+      g169 = glog((cone*(r1 - r2*r3*r6))/(r1 - xb*(-1 + xa + xb)),(cone*(r1 - r1*xa + r2*r3*r4*(-1 + xb) + xa*xb*(-2 + xa + xb)))/((
+     &-1 + xa)*(-r1 + xb*(-1 + xa + xb))),cone)
       g170 = glog((cone*(r1 + r2*r3*r6))/(r1 - xb*(-1 + xa + xb)),cone,cone)
       g171 = glog((cone*(r1 + r2*r3*r6))/(r1 - xb*(-1 + xa + xb)),(cone*(r1 - xa))/(r1 - xb*(-1 + xa + xb)),cone)
       g172 = glog((cone*(r1 + r2*r3*r6))/(r1 - xb*(-1 + xa + xb)),(cone*(r1 - xa*xb))/(r1 - xb*(-1 + xa + xb)),cone)
-      g173 = glog((cone*(r1 + r2*r3*r6))/(r1 - xb*(-1 + xa + xb)),(cone*(-(r1*(1 + xa)) - r2*r3*r4*(-1 + xb) + xa*xb*(xa + xb)))/((1 + xa)*(-r1 + xb*(-1 + xa + xb))),cone)
-      g174 = glog((cone*(r1 + r2*r3*r6))/(r1 - xb*(-1 + xa + xb)),(cone*(-(r1*(1 + xa)) + r2*r3*r4*(-1 + xb) + xa*xb*(xa + xb)))/((1 + xa)*(-r1 + xb*(-1 + xa + xb))),cone)
-      g175 = glog((cone*(r1 + r2*r3*r6))/(r1 - xb*(-1 + xa + xb)),(cone*(r1 - r1*xa - r2*r3*r4*(-1 + xb) + xa*xb*(-2 + xa + xb)))/((-1 + xa)*(-r1 + xb*(-1 + xa + xb))),cone)
-      g176 = glog((cone*(r1 + r2*r3*r6))/(r1 - xb*(-1 + xa + xb)),(cone*(r1 - r1*xa + r2*r3*r4*(-1 + xb) + xa*xb*(-2 + xa + xb)))/((-1 + xa)*(-r1 + xb*(-1 + xa + xb))),cone)
+      g173 = glog((cone*(r1 + r2*r3*r6))/(r1 - xb*(-1 + xa + xb)),(cone*(-(r1*(1 + xa)) - r2*r3*r4*(-1 + xb) + xa*xb*(xa + xb)))/((
+     &1 + xa)*(-r1 + xb*(-1 + xa + xb))),cone)
+      g174 = glog((cone*(r1 + r2*r3*r6))/(r1 - xb*(-1 + xa + xb)),(cone*(-(r1*(1 + xa)) + r2*r3*r4*(-1 + xb) + xa*xb*(xa + xb)))/((
+     &1 + xa)*(-r1 + xb*(-1 + xa + xb))),cone)
+      g175 = glog((cone*(r1 + r2*r3*r6))/(r1 - xb*(-1 + xa + xb)),(cone*(r1 - r1*xa - r2*r3*r4*(-1 + xb) + xa*xb*(-2 + xa + xb)))/((
+     &-1 + xa)*(-r1 + xb*(-1 + xa + xb))),cone)
+      g176 = glog((cone*(r1 + r2*r3*r6))/(r1 - xb*(-1 + xa + xb)),(cone*(r1 - r1*xa + r2*r3*r4*(-1 + xb) + xa*xb*(-2 + xa + xb)))/((
+     &-1 + xa)*(-r1 + xb*(-1 + xa + xb))),cone)
       g177 = glog((cone*(r2*r3*r6*(-1 + xb) + 2*xa*xb - r1*(1 + xb)))/((1 + xb)*(-r1 + xb*(-1 + xa + xb))),cone,cone)
-      g178 = glog((cone*(r2*r3*r6*(-1 + xb) + 2*xa*xb - r1*(1 + xb)))/((1 + xb)*(-r1 + xb*(-1 + xa + xb))),(cone*(r1 - xa))/(r1 - xb*(-1 + xa + xb)),cone)
-      g179 = glog((cone*(r2*r3*r6*(-1 + xb) + 2*xa*xb - r1*(1 + xb)))/((1 + xb)*(-r1 + xb*(-1 + xa + xb))),(cone*(r1 - xa*xb))/(r1 - xb*(-1 + xa + xb)),cone)
-      g180 = glog((cone*(r2*r3*r6*(-1 + xb) + 2*xa*xb - r1*(1 + xb)))/((1 + xb)*(-r1 + xb*(-1 + xa + xb))),(cone*(-(r1*(1 + xa)) - r2*r3*r4*(-1 + xb) + xa*xb*(xa + xb)))/((1 + xa)*(-r1 + xb*(-1 + xa + xb))),cone)
-      g181 = glog((cone*(r2*r3*r6*(-1 + xb) + 2*xa*xb - r1*(1 + xb)))/((1 + xb)*(-r1 + xb*(-1 + xa + xb))),(cone*(-(r1*(1 + xa)) + r2*r3*r4*(-1 + xb) + xa*xb*(xa + xb)))/((1 + xa)*(-r1 + xb*(-1 + xa + xb))),cone)
-      g182 = glog((cone*(r2*r3*r6*(-1 + xb) + 2*xa*xb - r1*(1 + xb)))/((1 + xb)*(-r1 + xb*(-1 + xa + xb))),(cone*(r1 - r1*xa - r2*r3*r4*(-1 + xb) + xa*xb*(-2 + xa + xb)))/((-1 + xa)*(-r1 + xb*(-1 + xa + xb))),cone)
-      g183 = glog((cone*(r2*r3*r6*(-1 + xb) + 2*xa*xb - r1*(1 + xb)))/((1 + xb)*(-r1 + xb*(-1 + xa + xb))),(cone*(r1 - r1*xa + r2*r3*r4*(-1 + xb) + xa*xb*(-2 + xa + xb)))/((-1 + xa)*(-r1 + xb*(-1 + xa + xb))),cone)
+      g178 = glog((cone*(r2*r3*r6*(-1 + xb) + 2*xa*xb - r1*(1 + xb)))/((1 + xb)*(-r1 + xb*(-1 + xa + xb))),(cone*(r1 - xa))/(r1 - 
+     &xb*(-1 + xa + xb)),cone)
+      g179 = glog((cone*(r2*r3*r6*(-1 + xb) + 2*xa*xb - r1*(1 + xb)))/((1 + xb)*(-r1 + xb*(-1 + xa + xb))),(cone*(r1 - xa*xb))/(r1 -
+     & xb*(-1 + xa + xb)),cone)
+      g180 = glog((cone*(r2*r3*r6*(-1 + xb) + 2*xa*xb - r1*(1 + xb)))/((1 + xb)*(-r1 + xb*(-1 + xa + xb))),(cone*(-(r1*(1 + xa)) - 
+     &r2*r3*r4*(-1 + xb) + xa*xb*(xa + xb)))/((1 + xa)*(-r1 + xb*(-1 + xa + xb))),cone)
+      g181 = glog((cone*(r2*r3*r6*(-1 + xb) + 2*xa*xb - r1*(1 + xb)))/((1 + xb)*(-r1 + xb*(-1 + xa + xb))),(cone*(-(r1*(1 + xa)) + 
+     &r2*r3*r4*(-1 + xb) + xa*xb*(xa + xb)))/((1 + xa)*(-r1 + xb*(-1 + xa + xb))),cone)
+      g182 = glog((cone*(r2*r3*r6*(-1 + xb) + 2*xa*xb - r1*(1 + xb)))/((1 + xb)*(-r1 + xb*(-1 + xa + xb))),(cone*(r1 - r1*xa - 
+     &r2*r3*r4*(-1 + xb) + xa*xb*(-2 + xa + xb)))/((-1 + xa)*(-r1 + xb*(-1 + xa + xb))),cone)
+      g183 = glog((cone*(r2*r3*r6*(-1 + xb) + 2*xa*xb - r1*(1 + xb)))/((1 + xb)*(-r1 + xb*(-1 + xa + xb))),(cone*(r1 - r1*xa + 
+     &r2*r3*r4*(-1 + xb) + xa*xb*(-2 + xa + xb)))/((-1 + xa)*(-r1 + xb*(-1 + xa + xb))),cone)
       g184 = glog(-((cone*(r2*r3*r6*(-1 + xb) - 2*xa*xb + r1*(1 + xb)))/((1 + xb)*(-r1 + xb*(-1 + xa + xb)))),cone,cone)
-      g185 = glog(-((cone*(r2*r3*r6*(-1 + xb) - 2*xa*xb + r1*(1 + xb)))/((1 + xb)*(-r1 + xb*(-1 + xa + xb)))),(cone*(r1 - xa))/(r1 - xb*(-1 + xa + xb)),cone)
-      g186 = glog(-((cone*(r2*r3*r6*(-1 + xb) - 2*xa*xb + r1*(1 + xb)))/((1 + xb)*(-r1 + xb*(-1 + xa + xb)))),(cone*(r1 - xa*xb))/(r1 - xb*(-1 + xa + xb)),cone)
-      g187 = glog(-((cone*(r2*r3*r6*(-1 + xb) - 2*xa*xb + r1*(1 + xb)))/((1 + xb)*(-r1 + xb*(-1 + xa + xb)))),(cone*(-(r1*(1 + xa)) - r2*r3*r4*(-1 + xb) + xa*xb*(xa + xb)))/((1 + xa)*(-r1 + xb*(-1 + xa + xb))),cone)
-      g188 = glog(-((cone*(r2*r3*r6*(-1 + xb) - 2*xa*xb + r1*(1 + xb)))/((1 + xb)*(-r1 + xb*(-1 + xa + xb)))),(cone*(-(r1*(1 + xa)) + r2*r3*r4*(-1 + xb) + xa*xb*(xa + xb)))/((1 + xa)*(-r1 + xb*(-1 + xa + xb))),cone)
-      g189 = glog(-((cone*(r2*r3*r6*(-1 + xb) - 2*xa*xb + r1*(1 + xb)))/((1 + xb)*(-r1 + xb*(-1 + xa + xb)))),(cone*(r1 - r1*xa - r2*r3*r4*(-1 + xb) + xa*xb*(-2 + xa + xb)))/((-1 + xa)*(-r1 + xb*(-1 + xa + xb))),cone)
-      g190 = glog(-((cone*(r2*r3*r6*(-1 + xb) - 2*xa*xb + r1*(1 + xb)))/((1 + xb)*(-r1 + xb*(-1 + xa + xb)))),(cone*(r1 - r1*xa + r2*r3*r4*(-1 + xb) + xa*xb*(-2 + xa + xb)))/((-1 + xa)*(-r1 + xb*(-1 + xa + xb))),cone)
-      g191 = glog((cone*(-xa + xb - r1*(-2 + xa + xb) + (-1 + xa)*xb*(xa + xb)))/((-2 + xa + xb)*(-r1 + xb*(-1 + xa + xb))),cone,cone)
+      g185 = glog(-((cone*(r2*r3*r6*(-1 + xb) - 2*xa*xb + r1*(1 + xb)))/((1 + xb)*(-r1 + xb*(-1 + xa + xb)))),(cone*(r1 - xa))/(r1 -
+     & xb*(-1 + xa + xb)),cone)
+      g186 = glog(-((cone*(r2*r3*r6*(-1 + xb) - 2*xa*xb + r1*(1 + xb)))/((1 + xb)*(-r1 + xb*(-1 + xa + xb)))),(cone*(r1 - xa*xb))/(
+     &r1 - xb*(-1 + xa + xb)),cone)
+      g187 = glog(-((cone*(r2*r3*r6*(-1 + xb) - 2*xa*xb + r1*(1 + xb)))/((1 + xb)*(-r1 + xb*(-1 + xa + xb)))),(cone*(-(r1*(1 + xa)) 
+     &- r2*r3*r4*(-1 + xb) + xa*xb*(xa + xb)))/((1 + xa)*(-r1 + xb*(-1 + xa + xb))),cone)
+      g188 = glog(-((cone*(r2*r3*r6*(-1 + xb) - 2*xa*xb + r1*(1 + xb)))/((1 + xb)*(-r1 + xb*(-1 + xa + xb)))),(cone*(-(r1*(1 + xa)) 
+     &+ r2*r3*r4*(-1 + xb) + xa*xb*(xa + xb)))/((1 + xa)*(-r1 + xb*(-1 + xa + xb))),cone)
+      g189 = glog(-((cone*(r2*r3*r6*(-1 + xb) - 2*xa*xb + r1*(1 + xb)))/((1 + xb)*(-r1 + xb*(-1 + xa + xb)))),(cone*(r1 - r1*xa - 
+     &r2*r3*r4*(-1 + xb) + xa*xb*(-2 + xa + xb)))/((-1 + xa)*(-r1 + xb*(-1 + xa + xb))),cone)
+      g190 = glog(-((cone*(r2*r3*r6*(-1 + xb) - 2*xa*xb + r1*(1 + xb)))/((1 + xb)*(-r1 + xb*(-1 + xa + xb)))),(cone*(r1 - r1*xa + 
+     &r2*r3*r4*(-1 + xb) + xa*xb*(-2 + xa + xb)))/((-1 + xa)*(-r1 + xb*(-1 + xa + xb))),cone)
+      g191 = glog((cone*(-xa + xb - r1*(-2 + xa + xb) + (-1 + xa)*xb*(xa + xb)))/((-2 + xa + xb)*(-r1 + xb*(-1 + xa + xb))),cone,
+     &cone)
       g192 = glog((-2*cone*(r1*(-1 + xa + xb) + xa*(-1 + xb*(xa + xb))))/((-1 + xb)**2*(xa + xb)),cone,cone)
-      g193 = glog((-2*cone*(r1*(-1 + xa + xb) + xa*(-1 + xb*(xa + xb))))/((-1 + xb)**2*(xa + xb)),-((cone*(r1 + xa))/((-1 + xb)*(xa + xb))),cone)
-      g194 = glog((-2*cone*(r1*(-1 + xa + xb) + xa*(-1 + xb*(xa + xb))))/((-1 + xb)**2*(xa + xb)),(cone*(r1 + xa*xb))/(xb - xb**2),cone)
-      g195 = glog((-2*cone*(r1*(-1 + xa + xb) + xa*(-1 + xb*(xa + xb))))/((-1 + xb)**2*(xa + xb)),-((cone*(r1*(r5 + xb) + xb*(xa + r5*(-1 + xa + xb) - xa*(-1 + xb)*(xa + xb))))/((1 + xa)*(-1 + xb)*xb*(xa + xb))),cone)
-      g196 = glog((-2*cone*(r1*(-1 + xa + xb) + xa*(-1 + xb*(xa + xb))))/((-1 + xb)**2*(xa + xb)),(cone*(r1*(r5 + xb) + xb*(xa + r5*(-1 + xa + xb) + xa*(-1 + xb)*(xa + xb))))/((-1 + xa)*(-1 + xb)*xb*(xa + xb)),cone)
-      g197 = glog((-2*cone*(r1*(-1 + xa + xb) + xa*(-1 + xb*(xa + xb))))/((-1 + xb)**2*(xa + xb)),(cone*(r1*(r5 - xb) + xb*(-xa + r5*(-1 + xa + xb) + xa*(-1 + xb)*(xa + xb))))/((1 + xa)*(-1 + xb)*xb*(xa + xb)),cone)
-      g198 = glog((-2*cone*(r1*(-1 + xa + xb) + xa*(-1 + xb*(xa + xb))))/((-1 + xb)**2*(xa + xb)),(cone*(r1*(-r5 + xb) + xb*(xa - r5*(-1 + xa + xb) + xa*(-1 + xb)*(xa + xb))))/((-1 + xa)*(-1 + xb)*xb*(xa + xb)),cone)
+      g193 = glog((-2*cone*(r1*(-1 + xa + xb) + xa*(-1 + xb*(xa + xb))))/((-1 + xb)**2*(xa + xb)),-((cone*(r1 + xa))/((-1 + xb)*(xa 
+     &+ xb))),cone)
+      g194 = glog((-2*cone*(r1*(-1 + xa + xb) + xa*(-1 + xb*(xa + xb))))/((-1 + xb)**2*(xa + xb)),(cone*(r1 + xa*xb))/(xb - xb**2),
+     &cone)
+      g195 = glog((-2*cone*(r1*(-1 + xa + xb) + xa*(-1 + xb*(xa + xb))))/((-1 + xb)**2*(xa + xb)),-((cone*(r1*(r5 + xb) + xb*(xa + 
+     &r5*(-1 + xa + xb) - xa*(-1 + xb)*(xa + xb))))/((1 + xa)*(-1 + xb)*xb*(xa + xb))),cone)
+      g196 = glog((-2*cone*(r1*(-1 + xa + xb) + xa*(-1 + xb*(xa + xb))))/((-1 + xb)**2*(xa + xb)),(cone*(r1*(r5 + xb) + xb*(xa + 
+     &r5*(-1 + xa + xb) + xa*(-1 + xb)*(xa + xb))))/((-1 + xa)*(-1 + xb)*xb*(xa + xb)),cone)
+      g197 = glog((-2*cone*(r1*(-1 + xa + xb) + xa*(-1 + xb*(xa + xb))))/((-1 + xb)**2*(xa + xb)),(cone*(r1*(r5 - xb) + xb*(-xa + 
+     &r5*(-1 + xa + xb) + xa*(-1 + xb)*(xa + xb))))/((1 + xa)*(-1 + xb)*xb*(xa + xb)),cone)
+      g198 = glog((-2*cone*(r1*(-1 + xa + xb) + xa*(-1 + xb*(xa + xb))))/((-1 + xb)**2*(xa + xb)),(cone*(r1*(-r5 + xb) + xb*(xa - 
+     &r5*(-1 + xa + xb) + xa*(-1 + xb)*(xa + xb))))/((-1 + xa)*(-1 + xb)*xb*(xa + xb)),cone)
       g199 = glog(-((cone*(-xa + xb + r1*(-2 + xa + xb) + (-1 + xa)*xb*(xa + xb)))/((-1 + xb)**2*(xa + xb))),cone,cone)
       g200 = glog((cone*(-r7 - r8*r9 + r2*r3*(xa + xb)))/2.0_ki,(cone*(-r10 + r2))/r3,(cone*r11)/r19)
       g201 = glog((cone*(-r7 - r8*r9 + r2*r3*(xa + xb)))/2.0_ki,(cone*(-r10 + r2))/r3,(cone*r12)/r20)

--- a/src/Intcts/include/a12casbrcas_functions.h
+++ b/src/Intcts/include/a12casbrcas_functions.h
@@ -731,15 +731,19 @@
       l53 = mylog(cone*(r6 + xa*xb))
       l54 = mylog(cone*(r6 - im*r2*r3*(-1 + xb) + xa*xb))
       l55 = mylog(cone*(r6 + im*r2*r3*(-1 + xb) + xa*xb))
-      l56 = mylog(cone*(xa - xb + 2*r1*r2*r3*(-1 + xa)*(-1 + xb*(-1 + xa + xb)) + xb*(2*xa**3*xb + xb**2 + xa*(4 + (-4 + xb)*xb**2) + xa**2*(-3 + xb*(-4 + 3*xb)))))
-      l57 = mylog(cone*(xa - xb - 2*r1*r2*r3*(-1 + xa)*(-1 + xb*(-1 + xa + xb)) + xb*(2*xa**3*xb + xb**2 + xa*(4 + (-4 + xb)*xb**2) + xa**2*(-3 + xb*(-4 + 3*xb)))))
+      l56 = mylog(cone*(xa - xb + 2*r1*r2*r3*(-1 + xa)*(-1 + xb*(-1 + xa + xb)) + xb*(2*xa**3*xb + xb**2 + xa*(4 + (-4 + xb)*xb**2) 
+     &+ xa**2*(-3 + xb*(-4 + 3*xb)))))
+      l57 = mylog(cone*(xa - xb - 2*r1*r2*r3*(-1 + xa)*(-1 + xb*(-1 + xa + xb)) + xb*(2*xa**3*xb + xb**2 + xa*(4 + (-4 + xb)*xb**2) 
+     &+ xa**2*(-3 + xb*(-4 + 3*xb)))))
       l58 = mylog(cone*(r5*(-1 + xb) + xb - xa*xb*(-1 + xa + xb)))
       l59 = mylog(cone*(r5 + xb - r5*xb - xa*xb*(-1 + xa + xb)))
       l60 = mylog((cone*(-(r1*r2) + r3*xa))/(-(r1*r2) + r3))
       l61 = mylog((cone*(r1*r2 + r3*xa))/(r1*r2 + r3))
       l62 = mylog(2*cone*(xa + r6*(-1 + xa + xb) - xa*xb*(xa + xb)))
       l63 = mylog(cone*(r6*(-1 + xa) + xa - xa*xb*(-1 + xa + xb)))
-      l64 = mylog((cone*(-1 + r2)*(1 + r2)*(-1 + r3)*(1 + r3)*(r6 - xa)*xb*(r6*(1 + xa) + r2*r3*r4*(-1 + xb) - xa*xb*(xa + xb))*(-(r6*(1 + xa)) + r2*r3*r4*(-1 + xb) + xa*xb*(xa + xb)))/((1 + xa)*(-r6 + xa*xb)*(r6 - r6*xa - r2*r3*r4*(-1 + xb) + xa*xb*(-2 + xa + xb))*(r6 - r6*xa + r2*r3*r4*(-1 + xb) + xa*xb*(-2 + xa + xb))*(-r6 + xb*(-1 + xa + xb))))
+      l64 = mylog((cone*(-1 + r2)*(1 + r2)*(-1 + r3)*(1 + r3)*(r6 - xa)*xb*(r6*(1 + xa) + r2*r3*r4*(-1 + xb) - xa*xb*(xa + xb))*(-(
+     &r6*(1 + xa)) + r2*r3*r4*(-1 + xb) + xa*xb*(xa + xb)))/((1 + xa)*(-r6 + xa*xb)*(r6 - r6*xa - r2*r3*r4*(-1 + xb) + xa*xb*(
+     &-2 + xa + xb))*(r6 - r6*xa + r2*r3*r4*(-1 + xb) + xa*xb*(-2 + xa + xb))*(-r6 + xb*(-1 + xa + xb))))
       l65 = mylog((cone*(-1 + xb)*(xa + xb))/(r6 - xa))
       l66 = mylog((cone*(-1 + xb)*xb)/(r6 - xa*xb))
       l67 = mylog((cone*r3*(r2 + im*r3)*(-1 + xb))/(r2*r3*(-1 + xb) + im*(r6 - xa*xb)))
@@ -754,7 +758,8 @@
       l76 = mylog(cone*(r5*(r6 - xb)*(-1 + xb) + xb*(r6 - r6*xa*(-1 + xa + xb) + xa*(1 + xa - xa*xb*(xa + xb)))))
       l77 = mylog(cone*(-(r5*(-1 + xb)*(r6 + xb)) - xb*(r6*(-1 + xa*(-1 + xa + xb)) + xa*(1 - 2*xb + xa*(-1 + xb*(xa + xb))))))
       l78 = mylog(cone*(r5*(-1 + xb)*(r6 + xb) - xb*(r6*(-1 + xa*(-1 + xa + xb)) + xa*(1 - 2*xb + xa*(-1 + xb*(xa + xb))))))
-      l79 = mylog(-((cone*(-r7 - r8*r9 + r2*r3*xa + r2*r3*xb - (2*r11)/Sqrt((r2 + 1/Sqrt(xa + xb))/r2)))/(r7 + r8*r9 - r2*r3*(xa + xb))))
+      l79 = mylog(-((cone*(-r7 - r8*r9 + r2*r3*xa + r2*r3*xb - (2*r11)/Sqrt((r2 + 1/Sqrt(xa + xb))/r2)))/(r7 + r8*r9 - r2*r3*(xa + 
+     &xb))))
       l80 = mylog((cone*(r10 - r2))/r3)
       l81 = mylog((cone*(r10 + r2))/r3)
       l82 = mylog(cone*r13)
@@ -764,19 +769,26 @@
       l86 = mylog(cone*(-r1 + r10*r3))
       l87 = mylog(cone*(r1 + r10*r3))
       l88 = mylog((cone*(r7 + r8*r9 - r2*r3*xa - r2*r3*xb + (2*r12)/Sqrt(1 + r2/Sqrt(xa + xb))))/(r7 + r8*r9 - r2*r3*(xa + xb)))
-      l89 = mylog((cone*(-r7 + r8*r9 + r2*r3*xa + r2*r3*xb + (2*r11)/Sqrt((r2 + 1/Sqrt(xa + xb))/r2)))/(-r7 + r8*r9 + r2*r3*(xa + xb)))
+      l89 = mylog((cone*(-r7 + r8*r9 + r2*r3*xa + r2*r3*xb + (2*r11)/Sqrt((r2 + 1/Sqrt(xa + xb))/r2)))/(-r7 + r8*r9 + r2*r3*(xa + 
+     &xb)))
       l90 = mylog((cone*(-r7 + r8*r9 + r2*r3*xa + r2*r3*xb + (2*r12)/Sqrt(1 + r2/Sqrt(xa + xb))))/(-r7 + r8*r9 + r2*r3*(xa + xb)))
-      l91 = mylog((cone*(-r7 + r8*r9 + r2*r3*xa + r2*r3*xb - (2*r11)/Sqrt((r2 + 1/Sqrt(xa + xb))/r2)))/(-r7 + r8*r9 + r2*r3*(xa + xb)))
+      l91 = mylog((cone*(-r7 + r8*r9 + r2*r3*xa + r2*r3*xb - (2*r11)/Sqrt((r2 + 1/Sqrt(xa + xb))/r2)))/(-r7 + r8*r9 + r2*r3*(xa + 
+     &xb)))
       l92 = mylog((cone*(-r7 + r8*r9 + r2*r3*xa + r2*r3*xb - (2*r12)/Sqrt(1 + r2/Sqrt(xa + xb))))/(-r7 + r8*r9 + r2*r3*(xa + xb)))
-      l93 = mylog(-((cone*(-r7 - r8*r9 + r2*r3*xa + r2*r3*xb + (2*r11)/Sqrt((r2 + 1/Sqrt(xa + xb))/r2)))/(r7 + r8*r9 - r2*r3*(xa + xb))))
+      l93 = mylog(-((cone*(-r7 - r8*r9 + r2*r3*xa + r2*r3*xb + (2*r11)/Sqrt((r2 + 1/Sqrt(xa + xb))/r2)))/(r7 + r8*r9 - r2*r3*(xa + 
+     &xb))))
       l94 = mylog(-((cone*(-r7 - r8*r9 + r2*r3*xa + r2*r3*xb + (2*r12)/Sqrt(1 + r2/Sqrt(xa + xb))))/(r7 + r8*r9 - r2*r3*(xa + xb))))
-      l95 = mylog((cone*(r7 + r15*r8 + r2*r3*xa + r2*r3*xb + (2*r11)/Sqrt((r2 + 1/Sqrt(xa + xb))/r2)))/(r7 + r15*r8 + r2*r3*(xa + xb)))
+      l95 = mylog((cone*(r7 + r15*r8 + r2*r3*xa + r2*r3*xb + (2*r11)/Sqrt((r2 + 1/Sqrt(xa + xb))/r2)))/(r7 + r15*r8 + r2*r3*(xa + 
+     &xb)))
       l96 = mylog((cone*(r7 + r15*r8 + r2*r3*xa + r2*r3*xb + (2*r12)/Sqrt(1 + r2/Sqrt(xa + xb))))/(r7 + r15*r8 + r2*r3*(xa + xb)))
-      l97 = mylog((cone*(r7 - r15*r8 + r2*r3*xa + r2*r3*xb - (2*r11)/Sqrt((r2 + 1/Sqrt(xa + xb))/r2)))/(r7 - r15*r8 + r2*r3*(xa + xb)))
+      l97 = mylog((cone*(r7 - r15*r8 + r2*r3*xa + r2*r3*xb - (2*r11)/Sqrt((r2 + 1/Sqrt(xa + xb))/r2)))/(r7 - r15*r8 + r2*r3*(xa + 
+     &xb)))
       l98 = mylog((cone*(r7 - r15*r8 + r2*r3*xa + r2*r3*xb - (2*r12)/Sqrt(1 + r2/Sqrt(xa + xb))))/(r7 - r15*r8 + r2*r3*(xa + xb)))
-      l99 = mylog((cone*(r7 - r15*r8 + r2*r3*xa + r2*r3*xb + (2*r11)/Sqrt((r2 + 1/Sqrt(xa + xb))/r2)))/(r7 - r15*r8 + r2*r3*(xa + xb)))
+      l99 = mylog((cone*(r7 - r15*r8 + r2*r3*xa + r2*r3*xb + (2*r11)/Sqrt((r2 + 1/Sqrt(xa + xb))/r2)))/(r7 - r15*r8 + r2*r3*(xa + 
+     &xb)))
       l100 = mylog((cone*(r7 - r15*r8 + r2*r3*xa + r2*r3*xb + (2*r12)/Sqrt(1 + r2/Sqrt(xa + xb))))/(r7 - r15*r8 + r2*r3*(xa + xb)))
-      l101 = mylog((cone*(r7 + r15*r8 + r2*r3*xa + r2*r3*xb - (2*r11)/Sqrt((r2 + 1/Sqrt(xa + xb))/r2)))/(r7 + r15*r8 + r2*r3*(xa + xb)))
+      l101 = mylog((cone*(r7 + r15*r8 + r2*r3*xa + r2*r3*xb - (2*r11)/Sqrt((r2 + 1/Sqrt(xa + xb))/r2)))/(r7 + r15*r8 + r2*r3*(xa + 
+     &xb)))
       l102 = mylog((cone*(r7 + r15*r8 + r2*r3*xa + r2*r3*xb - (2*r12)/Sqrt(1 + r2/Sqrt(xa + xb))))/(r7 + r15*r8 + r2*r3*(xa + xb)))
       l103 = mylog((cone*(r1*r2 - r3)*(r1 + r2*r3))/((r1*r2 + r3)*(r1 - r2*r3)))
       d1 = cli2((cone*(1 - xb))/2.0_ki)
@@ -858,10 +870,14 @@
       g56 = glog(czip,(cone*(r5 + xa))/(xa - xa*xb),cone)
       g57 = glog(czip,-((cone*(r6 + xa))/((-1 + xb)*(xa + xb))),cone)
       g58 = glog(czip,(cone*(r6 + xa*xb))/(xb - xb**2),cone)
-      g59 = glog(czip,(cone*(-(r6*xb) + xa*xb*(-1 + xa*(-1 + xb) + (-1 + xb)*xb) - r5*(r6 + xb*(-1 + xa + xb))))/((1 + xa)*(-1 + xb)*xb*(xa + xb)),cone)
-      g60 = glog(czip,(cone*(r5*(r6 + xb*(-1 + xa + xb)) + xb*(r6 + xa*(1 + xa*(-1 + xb) + (-1 + xb)*xb))))/((-1 + xa)*(-1 + xb)*xb*(xa + xb)),cone)
-      g61 = glog(czip,(cone*(-(r6*xb) + xa*xb*(-1 + xa*(-1 + xb) + (-1 + xb)*xb) + r5*(r6 + xb*(-1 + xa + xb))))/((1 + xa)*(-1 + xb)*xb*(xa + xb)),cone)
-      g62 = glog(czip,(cone*(-(r5*(r6 + xb*(-1 + xa + xb))) + xb*(r6 + xa*(1 + xa*(-1 + xb) + (-1 + xb)*xb))))/((-1 + xa)*(-1 + xb)*xb*(xa + xb)),cone)
+      g59 = glog(czip,(cone*(-(r6*xb) + xa*xb*(-1 + xa*(-1 + xb) + (-1 + xb)*xb) - r5*(r6 + xb*(-1 + xa + xb))))/((1 + xa)*(-1 + xb)
+     &*xb*(xa + xb)),cone)
+      g60 = glog(czip,(cone*(r5*(r6 + xb*(-1 + xa + xb)) + xb*(r6 + xa*(1 + xa*(-1 + xb) + (-1 + xb)*xb))))/((-1 + xa)*(-1 + xb)
+     &*xb*(xa + xb)),cone)
+      g61 = glog(czip,(cone*(-(r6*xb) + xa*xb*(-1 + xa*(-1 + xb) + (-1 + xb)*xb) + r5*(r6 + xb*(-1 + xa + xb))))/((1 + xa)*(-1 + xb)
+     &*xb*(xa + xb)),cone)
+      g62 = glog(czip,(cone*(-(r5*(r6 + xb*(-1 + xa + xb))) + xb*(r6 + xa*(1 + xa*(-1 + xb) + (-1 + xb)*xb))))/((-1 + xa)*(-1 + xb)
+     &*xb*(xa + xb)),cone)
       g63 = glog(cone,-cone,cone*xa)
       g64 = glog(cone,-cone,cone*xb)
       g65 = glog(cone,czip,cone*xa)
@@ -1024,31 +1040,51 @@
       g222 = glog(-((cone*(r6 + xa))/((-1 + xb)*(xa + xb))),cone,cone)
       g223 = glog(-((cone*(r6 + xa))/((-1 + xb)*(xa + xb))),-((cone*(r6 + xa))/((-1 + xb)*(xa + xb))),cone)
       g224 = glog(-((cone*(r6 + xa))/((-1 + xb)*(xa + xb))),(cone*(r6 + xa*xb))/(xb - xb**2),cone)
-      g225 = glog(-((cone*(r6 + xa))/((-1 + xb)*(xa + xb))),(cone*(-(r6*xb) + xa*xb*(-1 + xa*(-1 + xb) + (-1 + xb)*xb) - r5*(r6 + xb*(-1 + xa + xb))))/((1 + xa)*(-1 + xb)*xb*(xa + xb)),cone)
-      g226 = glog(-((cone*(r6 + xa))/((-1 + xb)*(xa + xb))),(cone*(r5*(r6 + xb*(-1 + xa + xb)) + xb*(r6 + xa*(1 + xa*(-1 + xb) + (-1 + xb)*xb))))/((-1 + xa)*(-1 + xb)*xb*(xa + xb)),cone)
-      g227 = glog(-((cone*(r6 + xa))/((-1 + xb)*(xa + xb))),(cone*(-(r6*xb) + xa*xb*(-1 + xa*(-1 + xb) + (-1 + xb)*xb) + r5*(r6 + xb*(-1 + xa + xb))))/((1 + xa)*(-1 + xb)*xb*(xa + xb)),cone)
-      g228 = glog(-((cone*(r6 + xa))/((-1 + xb)*(xa + xb))),(cone*(-(r5*(r6 + xb*(-1 + xa + xb))) + xb*(r6 + xa*(1 + xa*(-1 + xb) + (-1 + xb)*xb))))/((-1 + xa)*(-1 + xb)*xb*(xa + xb)),cone)
+      g225 = glog(-((cone*(r6 + xa))/((-1 + xb)*(xa + xb))),(cone*(-(r6*xb) + xa*xb*(-1 + xa*(-1 + xb) + (-1 + xb)*xb) - r5*(r6 + 
+     &xb*(-1 + xa + xb))))/((1 + xa)*(-1 + xb)*xb*(xa + xb)),cone)
+      g226 = glog(-((cone*(r6 + xa))/((-1 + xb)*(xa + xb))),(cone*(r5*(r6 + xb*(-1 + xa + xb)) + xb*(r6 + xa*(1 + xa*(-1 + xb) + (-
+     &1 + xb)*xb))))/((-1 + xa)*(-1 + xb)*xb*(xa + xb)),cone)
+      g227 = glog(-((cone*(r6 + xa))/((-1 + xb)*(xa + xb))),(cone*(-(r6*xb) + xa*xb*(-1 + xa*(-1 + xb) + (-1 + xb)*xb) + r5*(r6 + 
+     &xb*(-1 + xa + xb))))/((1 + xa)*(-1 + xb)*xb*(xa + xb)),cone)
+      g228 = glog(-((cone*(r6 + xa))/((-1 + xb)*(xa + xb))),(cone*(-(r5*(r6 + xb*(-1 + xa + xb))) + xb*(r6 + xa*(1 + xa*(-1 + xb) + 
+     &(-1 + xb)*xb))))/((-1 + xa)*(-1 + xb)*xb*(xa + xb)),cone)
       g229 = glog((cone*(r2*r3*(-1 + xb) - (czip,1)*(r6 + xa*xb)))/((r2 + (czip,1)*r3)*r3*(-1 + xb)),cone,cone)
-      g230 = glog((cone*(r2*r3*(-1 + xb) - (czip,1)*(r6 + xa*xb)))/((r2 + (czip,1)*r3)*r3*(-1 + xb)),-((cone*(r6 + xa))/((-1 + xb)*(xa + xb))),cone)
-      g231 = glog((cone*(r2*r3*(-1 + xb) - (czip,1)*(r6 + xa*xb)))/((r2 + (czip,1)*r3)*r3*(-1 + xb)),(cone*(r6 + xa*xb))/(xb - xb**2),cone)
-      g232 = glog((cone*(r2*r3*(-1 + xb) - (czip,1)*(r6 + xa*xb)))/((r2 + (czip,1)*r3)*r3*(-1 + xb)),(cone*(-(r6*xb) + xa*xb*(-1 + xa*(-1 + xb) + (-1 + xb)*xb) - r5*(r6 + xb*(-1 + xa + xb))))/((1 + xa)*(-1 + xb)*xb*(xa + xb)),cone)
-      g233 = glog((cone*(r2*r3*(-1 + xb) - (czip,1)*(r6 + xa*xb)))/((r2 + (czip,1)*r3)*r3*(-1 + xb)),(cone*(r5*(r6 + xb*(-1 + xa + xb)) + xb*(r6 + xa*(1 + xa*(-1 + xb) + (-1 + xb)*xb))))/((-1 + xa)*(-1 + xb)*xb*(xa + xb)),cone)
-      g234 = glog((cone*(r2*r3*(-1 + xb) - (czip,1)*(r6 + xa*xb)))/((r2 + (czip,1)*r3)*r3*(-1 + xb)),(cone*(-(r6*xb) + xa*xb*(-1 + xa*(-1 + xb) + (-1 + xb)*xb) + r5*(r6 + xb*(-1 + xa + xb))))/((1 + xa)*(-1 + xb)*xb*(xa + xb)),cone)
-      g235 = glog((cone*(r2*r3*(-1 + xb) - (czip,1)*(r6 + xa*xb)))/((r2 + (czip,1)*r3)*r3*(-1 + xb)),(cone*(-(r5*(r6 + xb*(-1 + xa + xb))) + xb*(r6 + xa*(1 + xa*(-1 + xb) + (-1 + xb)*xb))))/((-1 + xa)*(-1 + xb)*xb*(xa + xb)),cone)
+      g230 = glog((cone*(r2*r3*(-1 + xb) - (czip,1)*(r6 + xa*xb)))/((r2 + (czip,1)*r3)*r3*(-1 + xb)),-((cone*(r6 + xa))/((-1 + xb)*(
+     &xa + xb))),cone)
+      g231 = glog((cone*(r2*r3*(-1 + xb) - (czip,1)*(r6 + xa*xb)))/((r2 + (czip,1)*r3)*r3*(-1 + xb)),(cone*(r6 + xa*xb))/(xb - 
+     &xb**2),cone)
+      g232 = glog((cone*(r2*r3*(-1 + xb) - (czip,1)*(r6 + xa*xb)))/((r2 + (czip,1)*r3)*r3*(-1 + xb)),(cone*(-(r6*xb) + xa*xb*(-1 + 
+     &xa*(-1 + xb) + (-1 + xb)*xb) - r5*(r6 + xb*(-1 + xa + xb))))/((1 + xa)*(-1 + xb)*xb*(xa + xb)),cone)
+      g233 = glog((cone*(r2*r3*(-1 + xb) - (czip,1)*(r6 + xa*xb)))/((r2 + (czip,1)*r3)*r3*(-1 + xb)),(cone*(r5*(r6 + xb*(-1 + xa + 
+     &xb)) + xb*(r6 + xa*(1 + xa*(-1 + xb) + (-1 + xb)*xb))))/((-1 + xa)*(-1 + xb)*xb*(xa + xb)),cone)
+      g234 = glog((cone*(r2*r3*(-1 + xb) - (czip,1)*(r6 + xa*xb)))/((r2 + (czip,1)*r3)*r3*(-1 + xb)),(cone*(-(r6*xb) + xa*xb*(-1 + 
+     &xa*(-1 + xb) + (-1 + xb)*xb) + r5*(r6 + xb*(-1 + xa + xb))))/((1 + xa)*(-1 + xb)*xb*(xa + xb)),cone)
+      g235 = glog((cone*(r2*r3*(-1 + xb) - (czip,1)*(r6 + xa*xb)))/((r2 + (czip,1)*r3)*r3*(-1 + xb)),(cone*(-(r5*(r6 + xb*(-1 + xa +
+     & xb))) + xb*(r6 + xa*(1 + xa*(-1 + xb) + (-1 + xb)*xb))))/((-1 + xa)*(-1 + xb)*xb*(xa + xb)),cone)
       g236 = glog((cone*(r2*r3*(-1 + xb) + (czip,1)*(r6 + xa*xb)))/((r2 - (czip,1)*r3)*r3*(-1 + r3**2)),cone,cone)
-      g237 = glog((cone*(r2*r3*(-1 + xb) + (czip,1)*(r6 + xa*xb)))/((r2 - (czip,1)*r3)*r3*(-1 + r3**2)),-((cone*(r6 + xa))/((-1 + xb)*(xa + xb))),cone)
-      g238 = glog((cone*(r2*r3*(-1 + xb) + (czip,1)*(r6 + xa*xb)))/((r2 - (czip,1)*r3)*r3*(-1 + r3**2)),(cone*(r6 + xa*xb))/(xb - xb**2),cone)
-      g239 = glog((cone*(r2*r3*(-1 + xb) + (czip,1)*(r6 + xa*xb)))/((r2 - (czip,1)*r3)*r3*(-1 + r3**2)),(cone*(-(r6*xb) + xa*xb*(-1 + xa*(-1 + xb) + (-1 + xb)*xb) - r5*(r6 + xb*(-1 + xa + xb))))/((1 + xa)*(-1 + xb)*xb*(xa + xb)),cone)
-      g240 = glog((cone*(r2*r3*(-1 + xb) + (czip,1)*(r6 + xa*xb)))/((r2 - (czip,1)*r3)*r3*(-1 + r3**2)),(cone*(r5*(r6 + xb*(-1 + xa + xb)) + xb*(r6 + xa*(1 + xa*(-1 + xb) + (-1 + xb)*xb))))/((-1 + xa)*(-1 + xb)*xb*(xa + xb)),cone)
-      g241 = glog((cone*(r2*r3*(-1 + xb) + (czip,1)*(r6 + xa*xb)))/((r2 - (czip,1)*r3)*r3*(-1 + r3**2)),(cone*(-(r6*xb) + xa*xb*(-1 + xa*(-1 + xb) + (-1 + xb)*xb) + r5*(r6 + xb*(-1 + xa + xb))))/((1 + xa)*(-1 + xb)*xb*(xa + xb)),cone)
-      g242 = glog((cone*(r2*r3*(-1 + xb) + (czip,1)*(r6 + xa*xb)))/((r2 - (czip,1)*r3)*r3*(-1 + r3**2)),(cone*(-(r5*(r6 + xb*(-1 + xa + xb))) + xb*(r6 + xa*(1 + xa*(-1 + xb) + (-1 + xb)*xb))))/((-1 + xa)*(-1 + xb)*xb*(xa + xb)),cone)
+      g237 = glog((cone*(r2*r3*(-1 + xb) + (czip,1)*(r6 + xa*xb)))/((r2 - (czip,1)*r3)*r3*(-1 + r3**2)),-((cone*(r6 + xa))/((-1 + 
+     &xb)*(xa + xb))),cone)
+      g238 = glog((cone*(r2*r3*(-1 + xb) + (czip,1)*(r6 + xa*xb)))/((r2 - (czip,1)*r3)*r3*(-1 + r3**2)),(cone*(r6 + xa*xb))/(xb - 
+     &xb**2),cone)
+      g239 = glog((cone*(r2*r3*(-1 + xb) + (czip,1)*(r6 + xa*xb)))/((r2 - (czip,1)*r3)*r3*(-1 + r3**2)),(cone*(-(r6*xb) + xa*xb*(-1 
+     &+ xa*(-1 + xb) + (-1 + xb)*xb) - r5*(r6 + xb*(-1 + xa + xb))))/((1 + xa)*(-1 + xb)*xb*(xa + xb)),cone)
+      g240 = glog((cone*(r2*r3*(-1 + xb) + (czip,1)*(r6 + xa*xb)))/((r2 - (czip,1)*r3)*r3*(-1 + r3**2)),(cone*(r5*(r6 + xb*(-1 + xa 
+     &+ xb)) + xb*(r6 + xa*(1 + xa*(-1 + xb) + (-1 + xb)*xb))))/((-1 + xa)*(-1 + xb)*xb*(xa + xb)),cone)
+      g241 = glog((cone*(r2*r3*(-1 + xb) + (czip,1)*(r6 + xa*xb)))/((r2 - (czip,1)*r3)*r3*(-1 + r3**2)),(cone*(-(r6*xb) + xa*xb*(-1 
+     &+ xa*(-1 + xb) + (-1 + xb)*xb) + r5*(r6 + xb*(-1 + xa + xb))))/((1 + xa)*(-1 + xb)*xb*(xa + xb)),cone)
+      g242 = glog((cone*(r2*r3*(-1 + xb) + (czip,1)*(r6 + xa*xb)))/((r2 - (czip,1)*r3)*r3*(-1 + r3**2)),(cone*(-(r5*(r6 + xb*(-1 + 
+     &xa + xb))) + xb*(r6 + xa*(1 + xa*(-1 + xb) + (-1 + xb)*xb))))/((-1 + xa)*(-1 + xb)*xb*(xa + xb)),cone)
       g243 = glog((-2*cone*(r6 + xa))/((xa + xb)*(-1 + xb**2)),cone,cone)
       g244 = glog((-2*cone*(r6 + xa))/((xa + xb)*(-1 + xb**2)),-((cone*(r6 + xa))/((-1 + xb)*(xa + xb))),cone)
       g245 = glog((-2*cone*(r6 + xa))/((xa + xb)*(-1 + xb**2)),(cone*(r6 + xa*xb))/(xb - xb**2),cone)
-      g246 = glog((-2*cone*(r6 + xa))/((xa + xb)*(-1 + xb**2)),(cone*(-(r6*xb) + xa*xb*(-1 + xa*(-1 + xb) + (-1 + xb)*xb) - r5*(r6 + xb*(-1 + xa + xb))))/((1 + xa)*(-1 + xb)*xb*(xa + xb)),cone)
-      g247 = glog((-2*cone*(r6 + xa))/((xa + xb)*(-1 + xb**2)),(cone*(r5*(r6 + xb*(-1 + xa + xb)) + xb*(r6 + xa*(1 + xa*(-1 + xb) + (-1 + xb)*xb))))/((-1 + xa)*(-1 + xb)*xb*(xa + xb)),cone)
-      g248 = glog((-2*cone*(r6 + xa))/((xa + xb)*(-1 + xb**2)),(cone*(-(r6*xb) + xa*xb*(-1 + xa*(-1 + xb) + (-1 + xb)*xb) + r5*(r6 + xb*(-1 + xa + xb))))/((1 + xa)*(-1 + xb)*xb*(xa + xb)),cone)
-      g249 = glog((-2*cone*(r6 + xa))/((xa + xb)*(-1 + xb**2)),(cone*(-(r5*(r6 + xb*(-1 + xa + xb))) + xb*(r6 + xa*(1 + xa*(-1 + xb) + (-1 + xb)*xb))))/((-1 + xa)*(-1 + xb)*xb*(xa + xb)),cone)
+      g246 = glog((-2*cone*(r6 + xa))/((xa + xb)*(-1 + xb**2)),(cone*(-(r6*xb) + xa*xb*(-1 + xa*(-1 + xb) + (-1 + xb)*xb) - r5*(r6 +
+     & xb*(-1 + xa + xb))))/((1 + xa)*(-1 + xb)*xb*(xa + xb)),cone)
+      g247 = glog((-2*cone*(r6 + xa))/((xa + xb)*(-1 + xb**2)),(cone*(r5*(r6 + xb*(-1 + xa + xb)) + xb*(r6 + xa*(1 + xa*(-1 + xb) + 
+     &(-1 + xb)*xb))))/((-1 + xa)*(-1 + xb)*xb*(xa + xb)),cone)
+      g248 = glog((-2*cone*(r6 + xa))/((xa + xb)*(-1 + xb**2)),(cone*(-(r6*xb) + xa*xb*(-1 + xa*(-1 + xb) + (-1 + xb)*xb) + r5*(r6 +
+     & xb*(-1 + xa + xb))))/((1 + xa)*(-1 + xb)*xb*(xa + xb)),cone)
+      g249 = glog((-2*cone*(r6 + xa))/((xa + xb)*(-1 + xb**2)),(cone*(-(r5*(r6 + xb*(-1 + xa + xb))) + xb*(r6 + xa*(1 + xa*(-1 + xb)
+     & + (-1 + xb)*xb))))/((-1 + xa)*(-1 + xb)*xb*(xa + xb)),cone)
       g250 = glog((cone*(-r6 + xb))/(xb - xa*xb),czip,cone)
       g251 = glog((cone*(-r6 + xb))/(xb - xa*xb),cone,cone)
       g252 = glog((cone*(-r6 + xb))/(xb - xa*xb),(-2*cone)/(-1 + xa),cone)
@@ -1065,82 +1101,137 @@
       g263 = glog((cone*(r6 + xa*xb))/(xb - xb**2),cone,cone)
       g264 = glog((cone*(r6 + xa*xb))/(xb - xb**2),-((cone*(r6 + xa))/((-1 + xb)*(xa + xb))),cone)
       g265 = glog((cone*(r6 + xa*xb))/(xb - xb**2),(cone*(r6 + xa*xb))/(xb - xb**2),cone)
-      g266 = glog((cone*(r6 + xa*xb))/(xb - xb**2),(cone*(-(r6*xb) + xa*xb*(-1 + xa*(-1 + xb) + (-1 + xb)*xb) - r5*(r6 + xb*(-1 + xa + xb))))/((1 + xa)*(-1 + xb)*xb*(xa + xb)),cone)
-      g267 = glog((cone*(r6 + xa*xb))/(xb - xb**2),(cone*(r5*(r6 + xb*(-1 + xa + xb)) + xb*(r6 + xa*(1 + xa*(-1 + xb) + (-1 + xb)*xb))))/((-1 + xa)*(-1 + xb)*xb*(xa + xb)),cone)
-      g268 = glog((cone*(r6 + xa*xb))/(xb - xb**2),(cone*(-(r6*xb) + xa*xb*(-1 + xa*(-1 + xb) + (-1 + xb)*xb) + r5*(r6 + xb*(-1 + xa + xb))))/((1 + xa)*(-1 + xb)*xb*(xa + xb)),cone)
-      g269 = glog((cone*(r6 + xa*xb))/(xb - xb**2),(cone*(-(r5*(r6 + xb*(-1 + xa + xb))) + xb*(r6 + xa*(1 + xa*(-1 + xb) + (-1 + xb)*xb))))/((-1 + xa)*(-1 + xb)*xb*(xa + xb)),cone)
+      g266 = glog((cone*(r6 + xa*xb))/(xb - xb**2),(cone*(-(r6*xb) + xa*xb*(-1 + xa*(-1 + xb) + (-1 + xb)*xb) - r5*(r6 + xb*(-1 + 
+     &xa + xb))))/((1 + xa)*(-1 + xb)*xb*(xa + xb)),cone)
+      g267 = glog((cone*(r6 + xa*xb))/(xb - xb**2),(cone*(r5*(r6 + xb*(-1 + xa + xb)) + xb*(r6 + xa*(1 + xa*(-1 + xb) + (-1 + xb)
+     &*xb))))/((-1 + xa)*(-1 + xb)*xb*(xa + xb)),cone)
+      g268 = glog((cone*(r6 + xa*xb))/(xb - xb**2),(cone*(-(r6*xb) + xa*xb*(-1 + xa*(-1 + xb) + (-1 + xb)*xb) + r5*(r6 + xb*(-1 + 
+     &xa + xb))))/((1 + xa)*(-1 + xb)*xb*(xa + xb)),cone)
+      g269 = glog((cone*(r6 + xa*xb))/(xb - xb**2),(cone*(-(r5*(r6 + xb*(-1 + xa + xb))) + xb*(r6 + xa*(1 + xa*(-1 + xb) + (-1 + xb)
+     &*xb))))/((-1 + xa)*(-1 + xb)*xb*(xa + xb)),cone)
       g270 = glog((-2*cone*(r6 + xa*xb))/(-1 + xb**2),cone,cone)
       g271 = glog((-2*cone*(r6 + xa*xb))/(-1 + xb**2),-((cone*(r6 + xa))/((-1 + xb)*(xa + xb))),cone)
       g272 = glog((-2*cone*(r6 + xa*xb))/(-1 + xb**2),(cone*(r6 + xa*xb))/(xb - xb**2),cone)
-      g273 = glog((-2*cone*(r6 + xa*xb))/(-1 + xb**2),(cone*(-(r6*xb) + xa*xb*(-1 + xa*(-1 + xb) + (-1 + xb)*xb) - r5*(r6 + xb*(-1 + xa + xb))))/((1 + xa)*(-1 + xb)*xb*(xa + xb)),cone)
-      g274 = glog((-2*cone*(r6 + xa*xb))/(-1 + xb**2),(cone*(r5*(r6 + xb*(-1 + xa + xb)) + xb*(r6 + xa*(1 + xa*(-1 + xb) + (-1 + xb)*xb))))/((-1 + xa)*(-1 + xb)*xb*(xa + xb)),cone)
-      g275 = glog((-2*cone*(r6 + xa*xb))/(-1 + xb**2),(cone*(-(r6*xb) + xa*xb*(-1 + xa*(-1 + xb) + (-1 + xb)*xb) + r5*(r6 + xb*(-1 + xa + xb))))/((1 + xa)*(-1 + xb)*xb*(xa + xb)),cone)
-      g276 = glog((-2*cone*(r6 + xa*xb))/(-1 + xb**2),(cone*(-(r5*(r6 + xb*(-1 + xa + xb))) + xb*(r6 + xa*(1 + xa*(-1 + xb) + (-1 + xb)*xb))))/((-1 + xa)*(-1 + xb)*xb*(xa + xb)),cone)
+      g273 = glog((-2*cone*(r6 + xa*xb))/(-1 + xb**2),(cone*(-(r6*xb) + xa*xb*(-1 + xa*(-1 + xb) + (-1 + xb)*xb) - r5*(r6 + xb*(-1 +
+     & xa + xb))))/((1 + xa)*(-1 + xb)*xb*(xa + xb)),cone)
+      g274 = glog((-2*cone*(r6 + xa*xb))/(-1 + xb**2),(cone*(r5*(r6 + xb*(-1 + xa + xb)) + xb*(r6 + xa*(1 + xa*(-1 + xb) + (-1 + xb)
+     &*xb))))/((-1 + xa)*(-1 + xb)*xb*(xa + xb)),cone)
+      g275 = glog((-2*cone*(r6 + xa*xb))/(-1 + xb**2),(cone*(-(r6*xb) + xa*xb*(-1 + xa*(-1 + xb) + (-1 + xb)*xb) + r5*(r6 + xb*(-1 +
+     & xa + xb))))/((1 + xa)*(-1 + xb)*xb*(xa + xb)),cone)
+      g276 = glog((-2*cone*(r6 + xa*xb))/(-1 + xb**2),(cone*(-(r5*(r6 + xb*(-1 + xa + xb))) + xb*(r6 + xa*(1 + xa*(-1 + xb) + (-1 + 
+     &xb)*xb))))/((-1 + xa)*(-1 + xb)*xb*(xa + xb)),cone)
       g277 = glog((cone*(r6 - xa))/(r6 - xb*(-1 + xa + xb)),cone,cone)
       g278 = glog((cone*(r6 - xa))/(r6 - xb*(-1 + xa + xb)),(cone*(r6 - xa))/(r6 - xb*(-1 + xa + xb)),cone)
       g279 = glog((cone*(r6 - xa))/(r6 - xb*(-1 + xa + xb)),(cone*(r6 - xa*xb))/(r6 - xb*(-1 + xa + xb)),cone)
-      g280 = glog((cone*(r6 - xa))/(r6 - xb*(-1 + xa + xb)),(cone*(-(r6*(1 + xa)) - r2*r3*r4*(-1 + xb) + xa*xb*(xa + xb)))/((1 + xa)*(-r6 + xb*(-1 + xa + xb))),cone)
-      g281 = glog((cone*(r6 - xa))/(r6 - xb*(-1 + xa + xb)),(cone*(-(r6*(1 + xa)) + r2*r3*r4*(-1 + xb) + xa*xb*(xa + xb)))/((1 + xa)*(-r6 + xb*(-1 + xa + xb))),cone)
-      g282 = glog((cone*(r6 - xa))/(r6 - xb*(-1 + xa + xb)),(cone*(r6 - r6*xa - r2*r3*r4*(-1 + xb) + xa*xb*(-2 + xa + xb)))/((-1 + xa)*(-r6 + xb*(-1 + xa + xb))),cone)
-      g283 = glog((cone*(r6 - xa))/(r6 - xb*(-1 + xa + xb)),(cone*(r6 - r6*xa + r2*r3*r4*(-1 + xb) + xa*xb*(-2 + xa + xb)))/((-1 + xa)*(-r6 + xb*(-1 + xa + xb))),cone)
+      g280 = glog((cone*(r6 - xa))/(r6 - xb*(-1 + xa + xb)),(cone*(-(r6*(1 + xa)) - r2*r3*r4*(-1 + xb) + xa*xb*(xa + xb)))/((1 + xa)
+     &*(-r6 + xb*(-1 + xa + xb))),cone)
+      g281 = glog((cone*(r6 - xa))/(r6 - xb*(-1 + xa + xb)),(cone*(-(r6*(1 + xa)) + r2*r3*r4*(-1 + xb) + xa*xb*(xa + xb)))/((1 + xa)
+     &*(-r6 + xb*(-1 + xa + xb))),cone)
+      g282 = glog((cone*(r6 - xa))/(r6 - xb*(-1 + xa + xb)),(cone*(r6 - r6*xa - r2*r3*r4*(-1 + xb) + xa*xb*(-2 + xa + xb)))/((-1 + 
+     &xa)*(-r6 + xb*(-1 + xa + xb))),cone)
+      g283 = glog((cone*(r6 - xa))/(r6 - xb*(-1 + xa + xb)),(cone*(r6 - r6*xa + r2*r3*r4*(-1 + xb) + xa*xb*(-2 + xa + xb)))/((-1 + 
+     &xa)*(-r6 + xb*(-1 + xa + xb))),cone)
       g284 = glog((cone*(r6 - xb))/(r6 - xb*(-1 + xa + xb)),cone,cone)
       g285 = glog((cone*(r6 - xa*xb))/(r6 - xb*(-1 + xa + xb)),cone,cone)
       g286 = glog((cone*(r6 - xa*xb))/(r6 - xb*(-1 + xa + xb)),(cone*(r6 - xa))/(r6 - xb*(-1 + xa + xb)),cone)
       g287 = glog((cone*(r6 - xa*xb))/(r6 - xb*(-1 + xa + xb)),(cone*(r6 - xa*xb))/(r6 - xb*(-1 + xa + xb)),cone)
-      g288 = glog((cone*(r6 - xa*xb))/(r6 - xb*(-1 + xa + xb)),(cone*(-(r6*(1 + xa)) - r2*r3*r4*(-1 + xb) + xa*xb*(xa + xb)))/((1 + xa)*(-r6 + xb*(-1 + xa + xb))),cone)
-      g289 = glog((cone*(r6 - xa*xb))/(r6 - xb*(-1 + xa + xb)),(cone*(-(r6*(1 + xa)) + r2*r3*r4*(-1 + xb) + xa*xb*(xa + xb)))/((1 + xa)*(-r6 + xb*(-1 + xa + xb))),cone)
-      g290 = glog((cone*(r6 - xa*xb))/(r6 - xb*(-1 + xa + xb)),(cone*(r6 - r6*xa - r2*r3*r4*(-1 + xb) + xa*xb*(-2 + xa + xb)))/((-1 + xa)*(-r6 + xb*(-1 + xa + xb))),cone)
-      g291 = glog((cone*(r6 - xa*xb))/(r6 - xb*(-1 + xa + xb)),(cone*(r6 - r6*xa + r2*r3*r4*(-1 + xb) + xa*xb*(-2 + xa + xb)))/((-1 + xa)*(-r6 + xb*(-1 + xa + xb))),cone)
+      g288 = glog((cone*(r6 - xa*xb))/(r6 - xb*(-1 + xa + xb)),(cone*(-(r6*(1 + xa)) - r2*r3*r4*(-1 + xb) + xa*xb*(xa + xb)))/((1 + 
+     &xa)*(-r6 + xb*(-1 + xa + xb))),cone)
+      g289 = glog((cone*(r6 - xa*xb))/(r6 - xb*(-1 + xa + xb)),(cone*(-(r6*(1 + xa)) + r2*r3*r4*(-1 + xb) + xa*xb*(xa + xb)))/((1 + 
+     &xa)*(-r6 + xb*(-1 + xa + xb))),cone)
+      g290 = glog((cone*(r6 - xa*xb))/(r6 - xb*(-1 + xa + xb)),(cone*(r6 - r6*xa - r2*r3*r4*(-1 + xb) + xa*xb*(-2 + xa + xb)))/((-1 
+     &+ xa)*(-r6 + xb*(-1 + xa + xb))),cone)
+      g291 = glog((cone*(r6 - xa*xb))/(r6 - xb*(-1 + xa + xb)),(cone*(r6 - r6*xa + r2*r3*r4*(-1 + xb) + xa*xb*(-2 + xa + xb)))/((-1 
+     &+ xa)*(-r6 + xb*(-1 + xa + xb))),cone)
       g292 = glog((cone*(r6 - (czip,1)*r2*r3*(-1 + xb) - xa*xb))/(r6 - xb*(-1 + xa + xb)),cone,cone)
-      g293 = glog((cone*(r6 - (czip,1)*r2*r3*(-1 + xb) - xa*xb))/(r6 - xb*(-1 + xa + xb)),(cone*(r6 - xa))/(r6 - xb*(-1 + xa + xb)),cone)
-      g294 = glog((cone*(r6 - (czip,1)*r2*r3*(-1 + xb) - xa*xb))/(r6 - xb*(-1 + xa + xb)),(cone*(r6 - xa*xb))/(r6 - xb*(-1 + xa + xb)),cone)
-      g295 = glog((cone*(r6 - (czip,1)*r2*r3*(-1 + xb) - xa*xb))/(r6 - xb*(-1 + xa + xb)),(cone*(-(r6*(1 + xa)) - r2*r3*r4*(-1 + xb) + xa*xb*(xa + xb)))/((1 + xa)*(-r6 + xb*(-1 + xa + xb))),cone)
-      g296 = glog((cone*(r6 - (czip,1)*r2*r3*(-1 + xb) - xa*xb))/(r6 - xb*(-1 + xa + xb)),(cone*(-(r6*(1 + xa)) + r2*r3*r4*(-1 + xb) + xa*xb*(xa + xb)))/((1 + xa)*(-r6 + xb*(-1 + xa + xb))),cone)
-      g297 = glog((cone*(r6 - (czip,1)*r2*r3*(-1 + xb) - xa*xb))/(r6 - xb*(-1 + xa + xb)),(cone*(r6 - r6*xa - r2*r3*r4*(-1 + xb) + xa*xb*(-2 + xa + xb)))/((-1 + xa)*(-r6 + xb*(-1 + xa + xb))),cone)
-      g298 = glog((cone*(r6 - (czip,1)*r2*r3*(-1 + xb) - xa*xb))/(r6 - xb*(-1 + xa + xb)),(cone*(r6 - r6*xa + r2*r3*r4*(-1 + xb) + xa*xb*(-2 + xa + xb)))/((-1 + xa)*(-r6 + xb*(-1 + xa + xb))),cone)
+      g293 = glog((cone*(r6 - (czip,1)*r2*r3*(-1 + xb) - xa*xb))/(r6 - xb*(-1 + xa + xb)),(cone*(r6 - xa))/(r6 - xb*(-1 + xa + xb)),
+     &cone)
+      g294 = glog((cone*(r6 - (czip,1)*r2*r3*(-1 + xb) - xa*xb))/(r6 - xb*(-1 + xa + xb)),(cone*(r6 - xa*xb))/(r6 - xb*(-1 + xa + 
+     &xb)),cone)
+      g295 = glog((cone*(r6 - (czip,1)*r2*r3*(-1 + xb) - xa*xb))/(r6 - xb*(-1 + xa + xb)),(cone*(-(r6*(1 + xa)) - r2*r3*r4*(-1 + xb)
+     & + xa*xb*(xa + xb)))/((1 + xa)*(-r6 + xb*(-1 + xa + xb))),cone)
+      g296 = glog((cone*(r6 - (czip,1)*r2*r3*(-1 + xb) - xa*xb))/(r6 - xb*(-1 + xa + xb)),(cone*(-(r6*(1 + xa)) + r2*r3*r4*(-1 + xb)
+     & + xa*xb*(xa + xb)))/((1 + xa)*(-r6 + xb*(-1 + xa + xb))),cone)
+      g297 = glog((cone*(r6 - (czip,1)*r2*r3*(-1 + xb) - xa*xb))/(r6 - xb*(-1 + xa + xb)),(cone*(r6 - r6*xa - r2*r3*r4*(-1 + xb) + 
+     &xa*xb*(-2 + xa + xb)))/((-1 + xa)*(-r6 + xb*(-1 + xa + xb))),cone)
+      g298 = glog((cone*(r6 - (czip,1)*r2*r3*(-1 + xb) - xa*xb))/(r6 - xb*(-1 + xa + xb)),(cone*(r6 - r6*xa + r2*r3*r4*(-1 + xb) + 
+     &xa*xb*(-2 + xa + xb)))/((-1 + xa)*(-r6 + xb*(-1 + xa + xb))),cone)
       g299 = glog((cone*(r6 + (czip,1)*r2*r3*(-1 + xb) - xa*xb))/(r6 - xb*(-1 + xa + xb)),cone,cone)
-      g300 = glog((cone*(r6 + (czip,1)*r2*r3*(-1 + xb) - xa*xb))/(r6 - xb*(-1 + xa + xb)),(cone*(r6 - xa))/(r6 - xb*(-1 + xa + xb)),cone)
-      g301 = glog((cone*(r6 + (czip,1)*r2*r3*(-1 + xb) - xa*xb))/(r6 - xb*(-1 + xa + xb)),(cone*(r6 - xa*xb))/(r6 - xb*(-1 + xa + xb)),cone)
-      g302 = glog((cone*(r6 + (czip,1)*r2*r3*(-1 + xb) - xa*xb))/(r6 - xb*(-1 + xa + xb)),(cone*(-(r6*(1 + xa)) - r2*r3*r4*(-1 + xb) + xa*xb*(xa + xb)))/((1 + xa)*(-r6 + xb*(-1 + xa + xb))),cone)
-      g303 = glog((cone*(r6 + (czip,1)*r2*r3*(-1 + xb) - xa*xb))/(r6 - xb*(-1 + xa + xb)),(cone*(-(r6*(1 + xa)) + r2*r3*r4*(-1 + xb) + xa*xb*(xa + xb)))/((1 + xa)*(-r6 + xb*(-1 + xa + xb))),cone)
-      g304 = glog((cone*(r6 + (czip,1)*r2*r3*(-1 + xb) - xa*xb))/(r6 - xb*(-1 + xa + xb)),(cone*(r6 - r6*xa - r2*r3*r4*(-1 + xb) + xa*xb*(-2 + xa + xb)))/((-1 + xa)*(-r6 + xb*(-1 + xa + xb))),cone)
-      g305 = glog((cone*(r6 + (czip,1)*r2*r3*(-1 + xb) - xa*xb))/(r6 - xb*(-1 + xa + xb)),(cone*(r6 - r6*xa + r2*r3*r4*(-1 + xb) + xa*xb*(-2 + xa + xb)))/((-1 + xa)*(-r6 + xb*(-1 + xa + xb))),cone)
+      g300 = glog((cone*(r6 + (czip,1)*r2*r3*(-1 + xb) - xa*xb))/(r6 - xb*(-1 + xa + xb)),(cone*(r6 - xa))/(r6 - xb*(-1 + xa + xb)),
+     &cone)
+      g301 = glog((cone*(r6 + (czip,1)*r2*r3*(-1 + xb) - xa*xb))/(r6 - xb*(-1 + xa + xb)),(cone*(r6 - xa*xb))/(r6 - xb*(-1 + xa + 
+     &xb)),cone)
+      g302 = glog((cone*(r6 + (czip,1)*r2*r3*(-1 + xb) - xa*xb))/(r6 - xb*(-1 + xa + xb)),(cone*(-(r6*(1 + xa)) - r2*r3*r4*(-1 + xb)
+     & + xa*xb*(xa + xb)))/((1 + xa)*(-r6 + xb*(-1 + xa + xb))),cone)
+      g303 = glog((cone*(r6 + (czip,1)*r2*r3*(-1 + xb) - xa*xb))/(r6 - xb*(-1 + xa + xb)),(cone*(-(r6*(1 + xa)) + r2*r3*r4*(-1 + xb)
+     & + xa*xb*(xa + xb)))/((1 + xa)*(-r6 + xb*(-1 + xa + xb))),cone)
+      g304 = glog((cone*(r6 + (czip,1)*r2*r3*(-1 + xb) - xa*xb))/(r6 - xb*(-1 + xa + xb)),(cone*(r6 - r6*xa - r2*r3*r4*(-1 + xb) + 
+     &xa*xb*(-2 + xa + xb)))/((-1 + xa)*(-r6 + xb*(-1 + xa + xb))),cone)
+      g305 = glog((cone*(r6 + (czip,1)*r2*r3*(-1 + xb) - xa*xb))/(r6 - xb*(-1 + xa + xb)),(cone*(r6 - r6*xa + r2*r3*r4*(-1 + xb) + 
+     &xa*xb*(-2 + xa + xb)))/((-1 + xa)*(-r6 + xb*(-1 + xa + xb))),cone)
       g306 = glog((cone*(-(r1*r2*r3) + r6))/(r6 - xb*(-1 + xa + xb)),cone,cone)
       g307 = glog((cone*(-(r1*r2*r3) + r6))/(r6 - xb*(-1 + xa + xb)),(cone*(r6 - xa))/(r6 - xb*(-1 + xa + xb)),cone)
       g308 = glog((cone*(-(r1*r2*r3) + r6))/(r6 - xb*(-1 + xa + xb)),(cone*(r6 - xa*xb))/(r6 - xb*(-1 + xa + xb)),cone)
-      g309 = glog((cone*(-(r1*r2*r3) + r6))/(r6 - xb*(-1 + xa + xb)),(cone*(-(r6*(1 + xa)) - r2*r3*r4*(-1 + xb) + xa*xb*(xa + xb)))/((1 + xa)*(-r6 + xb*(-1 + xa + xb))),cone)
-      g310 = glog((cone*(-(r1*r2*r3) + r6))/(r6 - xb*(-1 + xa + xb)),(cone*(-(r6*(1 + xa)) + r2*r3*r4*(-1 + xb) + xa*xb*(xa + xb)))/((1 + xa)*(-r6 + xb*(-1 + xa + xb))),cone)
-      g311 = glog((cone*(-(r1*r2*r3) + r6))/(r6 - xb*(-1 + xa + xb)),(cone*(r6 - r6*xa - r2*r3*r4*(-1 + xb) + xa*xb*(-2 + xa + xb)))/((-1 + xa)*(-r6 + xb*(-1 + xa + xb))),cone)
-      g312 = glog((cone*(-(r1*r2*r3) + r6))/(r6 - xb*(-1 + xa + xb)),(cone*(r6 - r6*xa + r2*r3*r4*(-1 + xb) + xa*xb*(-2 + xa + xb)))/((-1 + xa)*(-r6 + xb*(-1 + xa + xb))),cone)
+      g309 = glog((cone*(-(r1*r2*r3) + r6))/(r6 - xb*(-1 + xa + xb)),(cone*(-(r6*(1 + xa)) - r2*r3*r4*(-1 + xb) + xa*xb*(xa + xb)))/
+     &((1 + xa)*(-r6 + xb*(-1 + xa + xb))),cone)
+      g310 = glog((cone*(-(r1*r2*r3) + r6))/(r6 - xb*(-1 + xa + xb)),(cone*(-(r6*(1 + xa)) + r2*r3*r4*(-1 + xb) + xa*xb*(xa + xb)))/
+     &((1 + xa)*(-r6 + xb*(-1 + xa + xb))),cone)
+      g311 = glog((cone*(-(r1*r2*r3) + r6))/(r6 - xb*(-1 + xa + xb)),(cone*(r6 - r6*xa - r2*r3*r4*(-1 + xb) + xa*xb*(-2 + xa + xb)))
+     &/((-1 + xa)*(-r6 + xb*(-1 + xa + xb))),cone)
+      g312 = glog((cone*(-(r1*r2*r3) + r6))/(r6 - xb*(-1 + xa + xb)),(cone*(r6 - r6*xa + r2*r3*r4*(-1 + xb) + xa*xb*(-2 + xa + xb)))
+     &/((-1 + xa)*(-r6 + xb*(-1 + xa + xb))),cone)
       g313 = glog((cone*(r1*r2*r3 + r6))/(r6 - xb*(-1 + xa + xb)),cone,cone)
       g314 = glog((cone*(r1*r2*r3 + r6))/(r6 - xb*(-1 + xa + xb)),(cone*(r6 - xa))/(r6 - xb*(-1 + xa + xb)),cone)
       g315 = glog((cone*(r1*r2*r3 + r6))/(r6 - xb*(-1 + xa + xb)),(cone*(r6 - xa*xb))/(r6 - xb*(-1 + xa + xb)),cone)
-      g316 = glog((cone*(r1*r2*r3 + r6))/(r6 - xb*(-1 + xa + xb)),(cone*(-(r6*(1 + xa)) - r2*r3*r4*(-1 + xb) + xa*xb*(xa + xb)))/((1 + xa)*(-r6 + xb*(-1 + xa + xb))),cone)
-      g317 = glog((cone*(r1*r2*r3 + r6))/(r6 - xb*(-1 + xa + xb)),(cone*(-(r6*(1 + xa)) + r2*r3*r4*(-1 + xb) + xa*xb*(xa + xb)))/((1 + xa)*(-r6 + xb*(-1 + xa + xb))),cone)
-      g318 = glog((cone*(r1*r2*r3 + r6))/(r6 - xb*(-1 + xa + xb)),(cone*(r6 - r6*xa - r2*r3*r4*(-1 + xb) + xa*xb*(-2 + xa + xb)))/((-1 + xa)*(-r6 + xb*(-1 + xa + xb))),cone)
-      g319 = glog((cone*(r1*r2*r3 + r6))/(r6 - xb*(-1 + xa + xb)),(cone*(r6 - r6*xa + r2*r3*r4*(-1 + xb) + xa*xb*(-2 + xa + xb)))/((-1 + xa)*(-r6 + xb*(-1 + xa + xb))),cone)
+      g316 = glog((cone*(r1*r2*r3 + r6))/(r6 - xb*(-1 + xa + xb)),(cone*(-(r6*(1 + xa)) - r2*r3*r4*(-1 + xb) + xa*xb*(xa + xb)))/((
+     &1 + xa)*(-r6 + xb*(-1 + xa + xb))),cone)
+      g317 = glog((cone*(r1*r2*r3 + r6))/(r6 - xb*(-1 + xa + xb)),(cone*(-(r6*(1 + xa)) + r2*r3*r4*(-1 + xb) + xa*xb*(xa + xb)))/((
+     &1 + xa)*(-r6 + xb*(-1 + xa + xb))),cone)
+      g318 = glog((cone*(r1*r2*r3 + r6))/(r6 - xb*(-1 + xa + xb)),(cone*(r6 - r6*xa - r2*r3*r4*(-1 + xb) + xa*xb*(-2 + xa + xb)))/((
+     &-1 + xa)*(-r6 + xb*(-1 + xa + xb))),cone)
+      g319 = glog((cone*(r1*r2*r3 + r6))/(r6 - xb*(-1 + xa + xb)),(cone*(r6 - r6*xa + r2*r3*r4*(-1 + xb) + xa*xb*(-2 + xa + xb)))/((
+     &-1 + xa)*(-r6 + xb*(-1 + xa + xb))),cone)
       g320 = glog((cone*(r1*r2*r3*(-1 + xb) + 2*xa*xb - r6*(1 + xb)))/((1 + xb)*(-r6 + xb*(-1 + xa + xb))),cone,cone)
-      g321 = glog((cone*(r1*r2*r3*(-1 + xb) + 2*xa*xb - r6*(1 + xb)))/((1 + xb)*(-r6 + xb*(-1 + xa + xb))),(cone*(r6 - xa))/(r6 - xb*(-1 + xa + xb)),cone)
-      g322 = glog((cone*(r1*r2*r3*(-1 + xb) + 2*xa*xb - r6*(1 + xb)))/((1 + xb)*(-r6 + xb*(-1 + xa + xb))),(cone*(r6 - xa*xb))/(r6 - xb*(-1 + xa + xb)),cone)
-      g323 = glog((cone*(r1*r2*r3*(-1 + xb) + 2*xa*xb - r6*(1 + xb)))/((1 + xb)*(-r6 + xb*(-1 + xa + xb))),(cone*(-(r6*(1 + xa)) - r2*r3*r4*(-1 + xb) + xa*xb*(xa + xb)))/((1 + xa)*(-r6 + xb*(-1 + xa + xb))),cone)
-      g324 = glog((cone*(r1*r2*r3*(-1 + xb) + 2*xa*xb - r6*(1 + xb)))/((1 + xb)*(-r6 + xb*(-1 + xa + xb))),(cone*(-(r6*(1 + xa)) + r2*r3*r4*(-1 + xb) + xa*xb*(xa + xb)))/((1 + xa)*(-r6 + xb*(-1 + xa + xb))),cone)
-      g325 = glog((cone*(r1*r2*r3*(-1 + xb) + 2*xa*xb - r6*(1 + xb)))/((1 + xb)*(-r6 + xb*(-1 + xa + xb))),(cone*(r6 - r6*xa - r2*r3*r4*(-1 + xb) + xa*xb*(-2 + xa + xb)))/((-1 + xa)*(-r6 + xb*(-1 + xa + xb))),cone)
-      g326 = glog((cone*(r1*r2*r3*(-1 + xb) + 2*xa*xb - r6*(1 + xb)))/((1 + xb)*(-r6 + xb*(-1 + xa + xb))),(cone*(r6 - r6*xa + r2*r3*r4*(-1 + xb) + xa*xb*(-2 + xa + xb)))/((-1 + xa)*(-r6 + xb*(-1 + xa + xb))),cone)
+      g321 = glog((cone*(r1*r2*r3*(-1 + xb) + 2*xa*xb - r6*(1 + xb)))/((1 + xb)*(-r6 + xb*(-1 + xa + xb))),(cone*(r6 - xa))/(r6 - 
+     &xb*(-1 + xa + xb)),cone)
+      g322 = glog((cone*(r1*r2*r3*(-1 + xb) + 2*xa*xb - r6*(1 + xb)))/((1 + xb)*(-r6 + xb*(-1 + xa + xb))),(cone*(r6 - xa*xb))/(r6 -
+     & xb*(-1 + xa + xb)),cone)
+      g323 = glog((cone*(r1*r2*r3*(-1 + xb) + 2*xa*xb - r6*(1 + xb)))/((1 + xb)*(-r6 + xb*(-1 + xa + xb))),(cone*(-(r6*(1 + xa)) - 
+     &r2*r3*r4*(-1 + xb) + xa*xb*(xa + xb)))/((1 + xa)*(-r6 + xb*(-1 + xa + xb))),cone)
+      g324 = glog((cone*(r1*r2*r3*(-1 + xb) + 2*xa*xb - r6*(1 + xb)))/((1 + xb)*(-r6 + xb*(-1 + xa + xb))),(cone*(-(r6*(1 + xa)) + 
+     &r2*r3*r4*(-1 + xb) + xa*xb*(xa + xb)))/((1 + xa)*(-r6 + xb*(-1 + xa + xb))),cone)
+      g325 = glog((cone*(r1*r2*r3*(-1 + xb) + 2*xa*xb - r6*(1 + xb)))/((1 + xb)*(-r6 + xb*(-1 + xa + xb))),(cone*(r6 - r6*xa - 
+     &r2*r3*r4*(-1 + xb) + xa*xb*(-2 + xa + xb)))/((-1 + xa)*(-r6 + xb*(-1 + xa + xb))),cone)
+      g326 = glog((cone*(r1*r2*r3*(-1 + xb) + 2*xa*xb - r6*(1 + xb)))/((1 + xb)*(-r6 + xb*(-1 + xa + xb))),(cone*(r6 - r6*xa + 
+     &r2*r3*r4*(-1 + xb) + xa*xb*(-2 + xa + xb)))/((-1 + xa)*(-r6 + xb*(-1 + xa + xb))),cone)
       g327 = glog(-((cone*(r6 + r1*r2*r3*(-1 + xb) + r6*xb - 2*xa*xb))/((1 + xb)*(-r6 + xb*(-1 + xa + xb)))),cone,cone)
-      g328 = glog(-((cone*(r6 + r1*r2*r3*(-1 + xb) + r6*xb - 2*xa*xb))/((1 + xb)*(-r6 + xb*(-1 + xa + xb)))),(cone*(r6 - xa))/(r6 - xb*(-1 + xa + xb)),cone)
-      g329 = glog(-((cone*(r6 + r1*r2*r3*(-1 + xb) + r6*xb - 2*xa*xb))/((1 + xb)*(-r6 + xb*(-1 + xa + xb)))),(cone*(r6 - xa*xb))/(r6 - xb*(-1 + xa + xb)),cone)
-      g330 = glog(-((cone*(r6 + r1*r2*r3*(-1 + xb) + r6*xb - 2*xa*xb))/((1 + xb)*(-r6 + xb*(-1 + xa + xb)))),(cone*(-(r6*(1 + xa)) - r2*r3*r4*(-1 + xb) + xa*xb*(xa + xb)))/((1 + xa)*(-r6 + xb*(-1 + xa + xb))),cone)
-      g331 = glog(-((cone*(r6 + r1*r2*r3*(-1 + xb) + r6*xb - 2*xa*xb))/((1 + xb)*(-r6 + xb*(-1 + xa + xb)))),(cone*(-(r6*(1 + xa)) + r2*r3*r4*(-1 + xb) + xa*xb*(xa + xb)))/((1 + xa)*(-r6 + xb*(-1 + xa + xb))),cone)
-      g332 = glog(-((cone*(r6 + r1*r2*r3*(-1 + xb) + r6*xb - 2*xa*xb))/((1 + xb)*(-r6 + xb*(-1 + xa + xb)))),(cone*(r6 - r6*xa - r2*r3*r4*(-1 + xb) + xa*xb*(-2 + xa + xb)))/((-1 + xa)*(-r6 + xb*(-1 + xa + xb))),cone)
-      g333 = glog(-((cone*(r6 + r1*r2*r3*(-1 + xb) + r6*xb - 2*xa*xb))/((1 + xb)*(-r6 + xb*(-1 + xa + xb)))),(cone*(r6 - r6*xa + r2*r3*r4*(-1 + xb) + xa*xb*(-2 + xa + xb)))/((-1 + xa)*(-r6 + xb*(-1 + xa + xb))),cone)
-      g334 = glog((cone*(-xa + xb - r6*(-2 + xa + xb) + (-1 + xa)*xb*(xa + xb)))/((-2 + xa + xb)*(-r6 + xb*(-1 + xa + xb))),cone,cone)
+      g328 = glog(-((cone*(r6 + r1*r2*r3*(-1 + xb) + r6*xb - 2*xa*xb))/((1 + xb)*(-r6 + xb*(-1 + xa + xb)))),(cone*(r6 - xa))/(r6 - 
+     &xb*(-1 + xa + xb)),cone)
+      g329 = glog(-((cone*(r6 + r1*r2*r3*(-1 + xb) + r6*xb - 2*xa*xb))/((1 + xb)*(-r6 + xb*(-1 + xa + xb)))),(cone*(r6 - xa*xb))/(
+     &r6 - xb*(-1 + xa + xb)),cone)
+      g330 = glog(-((cone*(r6 + r1*r2*r3*(-1 + xb) + r6*xb - 2*xa*xb))/((1 + xb)*(-r6 + xb*(-1 + xa + xb)))),(cone*(-(r6*(1 + xa)) -
+     & r2*r3*r4*(-1 + xb) + xa*xb*(xa + xb)))/((1 + xa)*(-r6 + xb*(-1 + xa + xb))),cone)
+      g331 = glog(-((cone*(r6 + r1*r2*r3*(-1 + xb) + r6*xb - 2*xa*xb))/((1 + xb)*(-r6 + xb*(-1 + xa + xb)))),(cone*(-(r6*(1 + xa)) +
+     & r2*r3*r4*(-1 + xb) + xa*xb*(xa + xb)))/((1 + xa)*(-r6 + xb*(-1 + xa + xb))),cone)
+      g332 = glog(-((cone*(r6 + r1*r2*r3*(-1 + xb) + r6*xb - 2*xa*xb))/((1 + xb)*(-r6 + xb*(-1 + xa + xb)))),(cone*(r6 - r6*xa - 
+     &r2*r3*r4*(-1 + xb) + xa*xb*(-2 + xa + xb)))/((-1 + xa)*(-r6 + xb*(-1 + xa + xb))),cone)
+      g333 = glog(-((cone*(r6 + r1*r2*r3*(-1 + xb) + r6*xb - 2*xa*xb))/((1 + xb)*(-r6 + xb*(-1 + xa + xb)))),(cone*(r6 - r6*xa + 
+     &r2*r3*r4*(-1 + xb) + xa*xb*(-2 + xa + xb)))/((-1 + xa)*(-r6 + xb*(-1 + xa + xb))),cone)
+      g334 = glog((cone*(-xa + xb - r6*(-2 + xa + xb) + (-1 + xa)*xb*(xa + xb)))/((-2 + xa + xb)*(-r6 + xb*(-1 + xa + xb))),cone,
+     &cone)
       g335 = glog((-2*cone*(r6*(-1 + xa + xb) + xa*(-1 + xb*(xa + xb))))/((-1 + xb)**2*(xa + xb)),cone,cone)
-      g336 = glog((-2*cone*(r6*(-1 + xa + xb) + xa*(-1 + xb*(xa + xb))))/((-1 + xb)**2*(xa + xb)),-((cone*(r6 + xa))/((-1 + xb)*(xa + xb))),cone)
-      g337 = glog((-2*cone*(r6*(-1 + xa + xb) + xa*(-1 + xb*(xa + xb))))/((-1 + xb)**2*(xa + xb)),(cone*(r6 + xa*xb))/(xb - xb**2),cone)
-      g338 = glog((-2*cone*(r6*(-1 + xa + xb) + xa*(-1 + xb*(xa + xb))))/((-1 + xb)**2*(xa + xb)),(cone*(-(r6*xb) + xa*xb*(-1 + xa*(-1 + xb) + (-1 + xb)*xb) - r5*(r6 + xb*(-1 + xa + xb))))/((1 + xa)*(-1 + xb)*xb*(xa + xb)),cone)
-      g339 = glog((-2*cone*(r6*(-1 + xa + xb) + xa*(-1 + xb*(xa + xb))))/((-1 + xb)**2*(xa + xb)),(cone*(r5*(r6 + xb*(-1 + xa + xb)) + xb*(r6 + xa*(1 + xa*(-1 + xb) + (-1 + xb)*xb))))/((-1 + xa)*(-1 + xb)*xb*(xa + xb)),cone)
-      g340 = glog((-2*cone*(r6*(-1 + xa + xb) + xa*(-1 + xb*(xa + xb))))/((-1 + xb)**2*(xa + xb)),(cone*(-(r6*xb) + xa*xb*(-1 + xa*(-1 + xb) + (-1 + xb)*xb) + r5*(r6 + xb*(-1 + xa + xb))))/((1 + xa)*(-1 + xb)*xb*(xa + xb)),cone)
-      g341 = glog((-2*cone*(r6*(-1 + xa + xb) + xa*(-1 + xb*(xa + xb))))/((-1 + xb)**2*(xa + xb)),(cone*(-(r5*(r6 + xb*(-1 + xa + xb))) + xb*(r6 + xa*(1 + xa*(-1 + xb) + (-1 + xb)*xb))))/((-1 + xa)*(-1 + xb)*xb*(xa + xb)),cone)
+      g336 = glog((-2*cone*(r6*(-1 + xa + xb) + xa*(-1 + xb*(xa + xb))))/((-1 + xb)**2*(xa + xb)),-((cone*(r6 + xa))/((-1 + xb)*(xa 
+     &+ xb))),cone)
+      g337 = glog((-2*cone*(r6*(-1 + xa + xb) + xa*(-1 + xb*(xa + xb))))/((-1 + xb)**2*(xa + xb)),(cone*(r6 + xa*xb))/(xb - xb**2),
+     &cone)
+      g338 = glog((-2*cone*(r6*(-1 + xa + xb) + xa*(-1 + xb*(xa + xb))))/((-1 + xb)**2*(xa + xb)),(cone*(-(r6*xb) + xa*xb*(-1 + xa*(
+     &-1 + xb) + (-1 + xb)*xb) - r5*(r6 + xb*(-1 + xa + xb))))/((1 + xa)*(-1 + xb)*xb*(xa + xb)),cone)
+      g339 = glog((-2*cone*(r6*(-1 + xa + xb) + xa*(-1 + xb*(xa + xb))))/((-1 + xb)**2*(xa + xb)),(cone*(r5*(r6 + xb*(-1 + xa + xb))
+     & + xb*(r6 + xa*(1 + xa*(-1 + xb) + (-1 + xb)*xb))))/((-1 + xa)*(-1 + xb)*xb*(xa + xb)),cone)
+      g340 = glog((-2*cone*(r6*(-1 + xa + xb) + xa*(-1 + xb*(xa + xb))))/((-1 + xb)**2*(xa + xb)),(cone*(-(r6*xb) + xa*xb*(-1 + xa*(
+     &-1 + xb) + (-1 + xb)*xb) + r5*(r6 + xb*(-1 + xa + xb))))/((1 + xa)*(-1 + xb)*xb*(xa + xb)),cone)
+      g341 = glog((-2*cone*(r6*(-1 + xa + xb) + xa*(-1 + xb*(xa + xb))))/((-1 + xb)**2*(xa + xb)),(cone*(-(r5*(r6 + xb*(-1 + xa + 
+     &xb))) + xb*(r6 + xa*(1 + xa*(-1 + xb) + (-1 + xb)*xb))))/((-1 + xa)*(-1 + xb)*xb*(xa + xb)),cone)
       g342 = glog(-((cone*(-xa + xb + r6*(-2 + xa + xb) + (-1 + xa)*xb*(xa + xb)))/((-1 + xb)**2*(xa + xb))),cone,cone)
       g343 = glog((cone*(-r7 - r8*r9 + r2*r3*(xa + xb)))/2.0_ki,(cone*(-r10 + r2))/r3,(cone*r11)/Sqrt((r2 + 1/Sqrt(xa + xb))/r2))
       g344 = glog((cone*(-r7 - r8*r9 + r2*r3*(xa + xb)))/2.0_ki,(cone*(-r10 + r2))/r3,(cone*r12)/Sqrt(1 + r2/Sqrt(xa + xb)))

--- a/src/Intcts/include/a2carbs_bulk_functions.h
+++ b/src/Intcts/include/a2carbs_bulk_functions.h
@@ -335,31 +335,49 @@
       g113 = glog((cone*xa*(1 + xb))/((-1 + xa)*xb),czip,cone)
       g114 = glog((cone*xa*(1 + xb))/((-1 + xa)*xb),cone,cone)
       g115 = glog((cone*xa*(1 + xb))/((-1 + xa)*xb),(cone*(1 + xa)*(1 + xb))/((-1 + xa)*(-1 + xb)),cone)
-      g116 = glog((cone*xa*(1 + xb))/((-1 + xa)*xb),-((cone*(r2*(1 - xa) + xa*xb**2 - xa**2*xb**2))/((-1 + xa)**2*(-1 + xb)*xb)),cone)
+      g116 = glog((cone*xa*(1 + xb))/((-1 + xa)*xb),-((cone*(r2*(1 - xa) + xa*xb**2 - xa**2*xb**2))/((-1 + xa)**2*(-1 + xb)*xb)),
+     &cone)
       g117 = glog((cone*xa*(1 + xb))/((-1 + xa)*xb),(cone*(r2*(1 - xa) - xa*xb**2 + xa**2*xb**2))/((-1 + xa)**2*(-1 + xb)*xb),cone)
       g118 = glog((cone*(-1 + xa*xb))/((-1 + xa)*(-1 + xb)),(cone*(1 + xa)*xb)/(xa*(-1 + xb)),cone)
       g119 = glog((cone*(-1 + xa*xb))/((-1 + xa)*(-1 + xb)),(cone*xa*(1 + xb))/((-1 + xa)*xb),cone)
-      g120 = glog((cone*(-1 + xa*xb))/((-1 + xa)*(-1 + xb)),(cone*(-(r1*(1 - xb)) + xa**2*(-1 + xb)*xb))/((-1 + xa)*xa*(-1 + xb)**2),cone)
-      g121 = glog((cone*(-1 + xa*xb))/((-1 + xa)*(-1 + xb)),(cone*(r1*(1 - xb) + xa**2*(-1 + xb)*xb))/((-1 + xa)*xa*(-1 + xb)**2),cone)
-      g122 = glog((cone*(-1 + xa*xb))/((-1 + xa)*(-1 + xb)),-((cone*(r2*(1 - xa) + xa*xb**2 - xa**2*xb**2))/((-1 + xa)**2*(-1 + xb)*xb)),cone)
-      g123 = glog((cone*(-1 + xa*xb))/((-1 + xa)*(-1 + xb)),(cone*(r2*(1 - xa) - xa*xb**2 + xa**2*xb**2))/((-1 + xa)**2*(-1 + xb)*xb),cone)
+      g120 = glog((cone*(-1 + xa*xb))/((-1 + xa)*(-1 + xb)),(cone*(-(r1*(1 - xb)) + xa**2*(-1 + xb)*xb))/((-1 + xa)*xa*(-1 + xb)**2)
+     &,cone)
+      g121 = glog((cone*(-1 + xa*xb))/((-1 + xa)*(-1 + xb)),(cone*(r1*(1 - xb) + xa**2*(-1 + xb)*xb))/((-1 + xa)*xa*(-1 + xb)**2),
+     &cone)
+      g122 = glog((cone*(-1 + xa*xb))/((-1 + xa)*(-1 + xb)),-((cone*(r2*(1 - xa) + xa*xb**2 - xa**2*xb**2))/((-1 + xa)**2*(-1 + xb)
+     &*xb)),cone)
+      g123 = glog((cone*(-1 + xa*xb))/((-1 + xa)*(-1 + xb)),(cone*(r2*(1 - xa) - xa*xb**2 + xa**2*xb**2))/((-1 + xa)**2*(-1 + xb)
+     &*xb),cone)
       g124 = glog((cone*(-(r1*(1 - xb)) + xa**2*(-1 + xb)*xb))/((-1 + xa)*xa*(-1 + xb)**2),cone,cone)
       g125 = glog((cone*(-(r1*(1 - xb)) + xa**2*(-1 + xb)*xb))/((-1 + xa)*xa*(-1 + xb)**2),(cone*(1 + xa)*xb)/(xa*(-1 + xb)),cone)
-      g126 = glog((cone*(-(r1*(1 - xb)) + xa**2*(-1 + xb)*xb))/((-1 + xa)*xa*(-1 + xb)**2),(cone*(1 + xa)*(1 + xb))/((-1 + xa)*(-1 + xb)),cone)
-      g127 = glog((cone*(-(r1*(1 - xb)) + xa**2*(-1 + xb)*xb))/((-1 + xa)*xa*(-1 + xb)**2),(cone*(-(r1*(1 - xb)) + xa**2*(-1 + xb)*xb))/((-1 + xa)*xa*(-1 + xb)**2),cone)
-      g128 = glog((cone*(-(r1*(1 - xb)) + xa**2*(-1 + xb)*xb))/((-1 + xa)*xa*(-1 + xb)**2),(cone*(r1*(1 - xb) + xa**2*(-1 + xb)*xb))/((-1 + xa)*xa*(-1 + xb)**2),cone)
+      g126 = glog((cone*(-(r1*(1 - xb)) + xa**2*(-1 + xb)*xb))/((-1 + xa)*xa*(-1 + xb)**2),(cone*(1 + xa)*(1 + xb))/((-1 + xa)*(-1 +
+     & xb)),cone)
+      g127 = glog((cone*(-(r1*(1 - xb)) + xa**2*(-1 + xb)*xb))/((-1 + xa)*xa*(-1 + xb)**2),(cone*(-(r1*(1 - xb)) + xa**2*(-1 + xb)
+     &*xb))/((-1 + xa)*xa*(-1 + xb)**2),cone)
+      g128 = glog((cone*(-(r1*(1 - xb)) + xa**2*(-1 + xb)*xb))/((-1 + xa)*xa*(-1 + xb)**2),(cone*(r1*(1 - xb) + xa**2*(-1 + xb)*xb))
+     &/((-1 + xa)*xa*(-1 + xb)**2),cone)
       g129 = glog((cone*(r1*(1 - xb) + xa**2*(-1 + xb)*xb))/((-1 + xa)*xa*(-1 + xb)**2),cone,cone)
       g130 = glog((cone*(r1*(1 - xb) + xa**2*(-1 + xb)*xb))/((-1 + xa)*xa*(-1 + xb)**2),(cone*(1 + xa)*xb)/(xa*(-1 + xb)),cone)
-      g131 = glog((cone*(r1*(1 - xb) + xa**2*(-1 + xb)*xb))/((-1 + xa)*xa*(-1 + xb)**2),(cone*(1 + xa)*(1 + xb))/((-1 + xa)*(-1 + xb)),cone)
-      g132 = glog((cone*(r1*(1 - xb) + xa**2*(-1 + xb)*xb))/((-1 + xa)*xa*(-1 + xb)**2),(cone*(-(r1*(1 - xb)) + xa**2*(-1 + xb)*xb))/((-1 + xa)*xa*(-1 + xb)**2),cone)
-      g133 = glog((cone*(r1*(1 - xb) + xa**2*(-1 + xb)*xb))/((-1 + xa)*xa*(-1 + xb)**2),(cone*(r1*(1 - xb) + xa**2*(-1 + xb)*xb))/((-1 + xa)*xa*(-1 + xb)**2),cone)
+      g131 = glog((cone*(r1*(1 - xb) + xa**2*(-1 + xb)*xb))/((-1 + xa)*xa*(-1 + xb)**2),(cone*(1 + xa)*(1 + xb))/((-1 + xa)*(-1 + 
+     &xb)),cone)
+      g132 = glog((cone*(r1*(1 - xb) + xa**2*(-1 + xb)*xb))/((-1 + xa)*xa*(-1 + xb)**2),(cone*(-(r1*(1 - xb)) + xa**2*(-1 + xb)*xb))
+     &/((-1 + xa)*xa*(-1 + xb)**2),cone)
+      g133 = glog((cone*(r1*(1 - xb) + xa**2*(-1 + xb)*xb))/((-1 + xa)*xa*(-1 + xb)**2),(cone*(r1*(1 - xb) + xa**2*(-1 + xb)*xb))/((
+     &-1 + xa)*xa*(-1 + xb)**2),cone)
       g134 = glog(-((cone*(r2*(1 - xa) + xa*xb**2 - xa**2*xb**2))/((-1 + xa)**2*(-1 + xb)*xb)),cone,cone)
-      g135 = glog(-((cone*(r2*(1 - xa) + xa*xb**2 - xa**2*xb**2))/((-1 + xa)**2*(-1 + xb)*xb)),(cone*(1 + xa)*(1 + xb))/((-1 + xa)*(-1 + xb)),cone)
-      g136 = glog(-((cone*(r2*(1 - xa) + xa*xb**2 - xa**2*xb**2))/((-1 + xa)**2*(-1 + xb)*xb)),(cone*xa*(1 + xb))/((-1 + xa)*xb),cone)
-      g137 = glog(-((cone*(r2*(1 - xa) + xa*xb**2 - xa**2*xb**2))/((-1 + xa)**2*(-1 + xb)*xb)),-((cone*(r2*(1 - xa) + xa*xb**2 - xa**2*xb**2))/((-1 + xa)**2*(-1 + xb)*xb)),cone)
-      g138 = glog(-((cone*(r2*(1 - xa) + xa*xb**2 - xa**2*xb**2))/((-1 + xa)**2*(-1 + xb)*xb)),(cone*(r2*(1 - xa) - xa*xb**2 + xa**2*xb**2))/((-1 + xa)**2*(-1 + xb)*xb),cone)
+      g135 = glog(-((cone*(r2*(1 - xa) + xa*xb**2 - xa**2*xb**2))/((-1 + xa)**2*(-1 + xb)*xb)),(cone*(1 + xa)*(1 + xb))/((-1 + xa)*(
+     &-1 + xb)),cone)
+      g136 = glog(-((cone*(r2*(1 - xa) + xa*xb**2 - xa**2*xb**2))/((-1 + xa)**2*(-1 + xb)*xb)),(cone*xa*(1 + xb))/((-1 + xa)*xb),
+     &cone)
+      g137 = glog(-((cone*(r2*(1 - xa) + xa*xb**2 - xa**2*xb**2))/((-1 + xa)**2*(-1 + xb)*xb)),-((cone*(r2*(1 - xa) + xa*xb**2 - 
+     &xa**2*xb**2))/((-1 + xa)**2*(-1 + xb)*xb)),cone)
+      g138 = glog(-((cone*(r2*(1 - xa) + xa*xb**2 - xa**2*xb**2))/((-1 + xa)**2*(-1 + xb)*xb)),(cone*(r2*(1 - xa) - xa*xb**2 + 
+     &xa**2*xb**2))/((-1 + xa)**2*(-1 + xb)*xb),cone)
       g139 = glog((cone*(r2*(1 - xa) - xa*xb**2 + xa**2*xb**2))/((-1 + xa)**2*(-1 + xb)*xb),cone,cone)
-      g140 = glog((cone*(r2*(1 - xa) - xa*xb**2 + xa**2*xb**2))/((-1 + xa)**2*(-1 + xb)*xb),(cone*(1 + xa)*(1 + xb))/((-1 + xa)*(-1 + xb)),cone)
+      g140 = glog((cone*(r2*(1 - xa) - xa*xb**2 + xa**2*xb**2))/((-1 + xa)**2*(-1 + xb)*xb),(cone*(1 + xa)*(1 + xb))/((-1 + xa)*(-1 
+     &+ xb)),cone)
       g141 = glog((cone*(r2*(1 - xa) - xa*xb**2 + xa**2*xb**2))/((-1 + xa)**2*(-1 + xb)*xb),(cone*xa*(1 + xb))/((-1 + xa)*xb),cone)
-      g142 = glog((cone*(r2*(1 - xa) - xa*xb**2 + xa**2*xb**2))/((-1 + xa)**2*(-1 + xb)*xb),-((cone*(r2*(1 - xa) + xa*xb**2 - xa**2*xb**2))/((-1 + xa)**2*(-1 + xb)*xb)),cone)
-      g143 = glog((cone*(r2*(1 - xa) - xa*xb**2 + xa**2*xb**2))/((-1 + xa)**2*(-1 + xb)*xb),(cone*(r2*(1 - xa) - xa*xb**2 + xa**2*xb**2))/((-1 + xa)**2*(-1 + xb)*xb),cone)
+      g142 = glog((cone*(r2*(1 - xa) - xa*xb**2 + xa**2*xb**2))/((-1 + xa)**2*(-1 + xb)*xb),-((cone*(r2*(1 - xa) + xa*xb**2 - 
+     &xa**2*xb**2))/((-1 + xa)**2*(-1 + xb)*xb)),cone)
+      g143 = glog((cone*(r2*(1 - xa) - xa*xb**2 + xa**2*xb**2))/((-1 + xa)**2*(-1 + xb)*xb),(cone*(r2*(1 - xa) - xa*xb**2 + 
+     &xa**2*xb**2))/((-1 + xa)**2*(-1 + xb)*xb),cone)

--- a/src/Intcts/include/a2cars_bulk_functions.h
+++ b/src/Intcts/include/a2cars_bulk_functions.h
@@ -251,8 +251,10 @@
       l27 = mylog(-((cone*(r2*(1 - xa) - xa*xb**2 + xa**2*xb**2))/((-1 + xa)**2*(-1 + xb)*xb)))
       l28 = mylog(cone*(1 - xa - xb + 2*xa*xb - 2*xa**2*xb**2 + xa**3*xb**3))
       l29 = mylog(cone*(2 - xb + xa**2*xb**2 - xa*(1 + xb)))
-      l30 = mylog((cone*(4*r4*xa + r5*xa - r4*xa**2 + r5*xb - 2*r4*xa*xb - xb**2.5_ki + (-r5 + r4*xa + r4*xb)*Abs(xa - xb)))/((r5 - r4*xa - r4*xb)*(xa + xb - Abs(xa - xb))))
-      l31 = mylog((cone*(-4*r4*xa + r5*xa + r4*xa**2 + r5*xb + 2*r4*xa*xb + xb**2.5_ki - (r5 + r4*xa + r4*xb)*Abs(xa - xb)))/((r5 + r4*xa + r4*xb)*(xa + xb - Abs(xa - xb))))
+      l30 = mylog((cone*(4*r4*xa + r5*xa - r4*xa**2 + r5*xb - 2*r4*xa*xb - xb**2.5_ki + (-r5 + r4*xa + r4*xb)*Abs(xa - xb)))/((r5 - 
+     &r4*xa - r4*xb)*(xa + xb - Abs(xa - xb))))
+      l31 = mylog((cone*(-4*r4*xa + r5*xa + r4*xa**2 + r5*xb + 2*r4*xa*xb + xb**2.5_ki - (r5 + r4*xa + r4*xb)*Abs(xa - xb)))/((r5 + 
+     &r4*xa + r4*xb)*(xa + xb - Abs(xa - xb))))
       g1 = glog(-2*cone,-cone,cone*xb)
       g2 = glog(-2*cone,czip,cone*xb)
       g3 = glog(-2*cone,2*cone,cone*xb)
@@ -354,7 +356,8 @@
       g99 = glog((cone*xa*(1 + xb))/((-1 + xa)*xb),(cone*xa*(1 + xb))/((-1 + xa)*xb),cone)
       g100 = glog((cone*xa*(1 + xb))/((-1 + xa)*xb),(cone*(1 - r1 + 2*xa*xb))/(2 - 2*xa - 2*xb + 2*xa*xb),cone)
       g101 = glog((cone*xa*(1 + xb))/((-1 + xa)*xb),(cone*(1 + r1 + 2*xa*xb))/(2 - 2*xa - 2*xb + 2*xa*xb),cone)
-      g102 = glog((cone*xa*(1 + xb))/((-1 + xa)*xb),-((cone*(r2*(1 - xa) + xa*xb**2 - xa**2*xb**2))/((-1 + xa)**2*(-1 + xb)*xb)),cone)
+      g102 = glog((cone*xa*(1 + xb))/((-1 + xa)*xb),-((cone*(r2*(1 - xa) + xa*xb**2 - xa**2*xb**2))/((-1 + xa)**2*(-1 + xb)*xb)),
+     &cone)
       g103 = glog((cone*xa*(1 + xb))/((-1 + xa)*xb),(cone*(r2*(1 - xa) - xa*xb**2 + xa**2*xb**2))/((-1 + xa)**2*(-1 + xb)*xb),cone)
       g104 = glog((cone*(-r5 + r4*xa + r4*xb))/(2.0_ki*r3),czip,cone/(r3*r4))
       g105 = glog((cone*(-r5 + r4*xa + r4*xb))/(2.0_ki*r3),czip,(2*cone*r3*r4)/(xa + xb - Abs(xa - xb)))
@@ -373,8 +376,10 @@
       g118 = glog((cone*(-1 + xa*xb))/((-1 + xa)*(-1 + xb)),(cone*(1 + xb))/(1 - xa),cone)
       g119 = glog((cone*(-1 + xa*xb))/((-1 + xa)*(-1 + xb)),(cone*(1 + xa)*(1 + xb))/((-1 + xa)*(-1 + xb)),cone)
       g120 = glog((cone*(-1 + xa*xb))/((-1 + xa)*(-1 + xb)),(cone*xa*(1 + xb))/((-1 + xa)*xb),cone)
-      g121 = glog((cone*(-1 + xa*xb))/((-1 + xa)*(-1 + xb)),-((cone*(r2*(1 - xa) + xa*xb**2 - xa**2*xb**2))/((-1 + xa)**2*(-1 + xb)*xb)),cone)
-      g122 = glog((cone*(-1 + xa*xb))/((-1 + xa)*(-1 + xb)),(cone*(r2*(1 - xa) - xa*xb**2 + xa**2*xb**2))/((-1 + xa)**2*(-1 + xb)*xb),cone)
+      g121 = glog((cone*(-1 + xa*xb))/((-1 + xa)*(-1 + xb)),-((cone*(r2*(1 - xa) + xa*xb**2 - xa**2*xb**2))/((-1 + xa)**2*(-1 + xb)
+     &*xb)),cone)
+      g122 = glog((cone*(-1 + xa*xb))/((-1 + xa)*(-1 + xb)),(cone*(r2*(1 - xa) - xa*xb**2 + xa**2*xb**2))/((-1 + xa)**2*(-1 + xb)
+     &*xb),cone)
       g123 = glog((cone*(1 + xa*xb))/((-1 + xa)*(-1 + xb)),czip,cone)
       g124 = glog((cone*(1 + xa*xb))/((-1 + xa)*(-1 + xb)),cone,cone)
       g125 = glog((cone*(1 + xa*xb))/((-1 + xa)*(-1 + xb)),(cone*(1 + xb))/(1 - xa),cone)
@@ -393,12 +398,19 @@
       g138 = glog((cone*(1 + r1 + 2*xa*xb))/(2 - 2*xa - 2*xb + 2*xa*xb),(cone*(1 - r1 + 2*xa*xb))/(2 - 2*xa - 2*xb + 2*xa*xb),cone)
       g139 = glog((cone*(1 + r1 + 2*xa*xb))/(2 - 2*xa - 2*xb + 2*xa*xb),(cone*(1 + r1 + 2*xa*xb))/(2 - 2*xa - 2*xb + 2*xa*xb),cone)
       g140 = glog(-((cone*(r2*(1 - xa) + xa*xb**2 - xa**2*xb**2))/((-1 + xa)**2*(-1 + xb)*xb)),cone,cone)
-      g141 = glog(-((cone*(r2*(1 - xa) + xa*xb**2 - xa**2*xb**2))/((-1 + xa)**2*(-1 + xb)*xb)),(cone*(1 + xa)*(1 + xb))/((-1 + xa)*(-1 + xb)),cone)
-      g142 = glog(-((cone*(r2*(1 - xa) + xa*xb**2 - xa**2*xb**2))/((-1 + xa)**2*(-1 + xb)*xb)),(cone*xa*(1 + xb))/((-1 + xa)*xb),cone)
-      g143 = glog(-((cone*(r2*(1 - xa) + xa*xb**2 - xa**2*xb**2))/((-1 + xa)**2*(-1 + xb)*xb)),-((cone*(r2*(1 - xa) + xa*xb**2 - xa**2*xb**2))/((-1 + xa)**2*(-1 + xb)*xb)),cone)
-      g144 = glog(-((cone*(r2*(1 - xa) + xa*xb**2 - xa**2*xb**2))/((-1 + xa)**2*(-1 + xb)*xb)),(cone*(r2*(1 - xa) - xa*xb**2 + xa**2*xb**2))/((-1 + xa)**2*(-1 + xb)*xb),cone)
+      g141 = glog(-((cone*(r2*(1 - xa) + xa*xb**2 - xa**2*xb**2))/((-1 + xa)**2*(-1 + xb)*xb)),(cone*(1 + xa)*(1 + xb))/((-1 + xa)*(
+     &-1 + xb)),cone)
+      g142 = glog(-((cone*(r2*(1 - xa) + xa*xb**2 - xa**2*xb**2))/((-1 + xa)**2*(-1 + xb)*xb)),(cone*xa*(1 + xb))/((-1 + xa)*xb),
+     &cone)
+      g143 = glog(-((cone*(r2*(1 - xa) + xa*xb**2 - xa**2*xb**2))/((-1 + xa)**2*(-1 + xb)*xb)),-((cone*(r2*(1 - xa) + xa*xb**2 - 
+     &xa**2*xb**2))/((-1 + xa)**2*(-1 + xb)*xb)),cone)
+      g144 = glog(-((cone*(r2*(1 - xa) + xa*xb**2 - xa**2*xb**2))/((-1 + xa)**2*(-1 + xb)*xb)),(cone*(r2*(1 - xa) - xa*xb**2 + 
+     &xa**2*xb**2))/((-1 + xa)**2*(-1 + xb)*xb),cone)
       g145 = glog((cone*(r2*(1 - xa) - xa*xb**2 + xa**2*xb**2))/((-1 + xa)**2*(-1 + xb)*xb),cone,cone)
-      g146 = glog((cone*(r2*(1 - xa) - xa*xb**2 + xa**2*xb**2))/((-1 + xa)**2*(-1 + xb)*xb),(cone*(1 + xa)*(1 + xb))/((-1 + xa)*(-1 + xb)),cone)
+      g146 = glog((cone*(r2*(1 - xa) - xa*xb**2 + xa**2*xb**2))/((-1 + xa)**2*(-1 + xb)*xb),(cone*(1 + xa)*(1 + xb))/((-1 + xa)*(-1 
+     &+ xb)),cone)
       g147 = glog((cone*(r2*(1 - xa) - xa*xb**2 + xa**2*xb**2))/((-1 + xa)**2*(-1 + xb)*xb),(cone*xa*(1 + xb))/((-1 + xa)*xb),cone)
-      g148 = glog((cone*(r2*(1 - xa) - xa*xb**2 + xa**2*xb**2))/((-1 + xa)**2*(-1 + xb)*xb),-((cone*(r2*(1 - xa) + xa*xb**2 - xa**2*xb**2))/((-1 + xa)**2*(-1 + xb)*xb)),cone)
-      g149 = glog((cone*(r2*(1 - xa) - xa*xb**2 + xa**2*xb**2))/((-1 + xa)**2*(-1 + xb)*xb),(cone*(r2*(1 - xa) - xa*xb**2 + xa**2*xb**2))/((-1 + xa)**2*(-1 + xb)*xb),cone)
+      g148 = glog((cone*(r2*(1 - xa) - xa*xb**2 + xa**2*xb**2))/((-1 + xa)**2*(-1 + xb)*xb),-((cone*(r2*(1 - xa) + xa*xb**2 - 
+     &xa**2*xb**2))/((-1 + xa)**2*(-1 + xb)*xb)),cone)
+      g149 = glog((cone*(r2*(1 - xa) - xa*xb**2 + xa**2*xb**2))/((-1 + xa)**2*(-1 + xb)*xb),(cone*(r2*(1 - xa) - xa*xb**2 + 
+     &xa**2*xb**2))/((-1 + xa)**2*(-1 + xb)*xb),cone)

--- a/src/Intcts/include/cts.h
+++ b/src/Intcts/include/cts.h
@@ -57,7 +57,8 @@
      1  na1a1cassssragg(0:2,0:2,-4:0),
      2  na1a1sscarsragg(0:2,0:2,-4:0),
      3  na1a1sssrgg(0:2,0:2,-4:0),
-     4  na1a1crssscarggg(0:2,0:2,-4:0), na1a1crssscargqg(0:2,0:2,-4:0), na1a1crssscarqgg(0:2,0:2,-4:0), na1a1crssscarqqg(0:2,0:2,-4:0),
+     4  na1a1crssscarggg(0:2,0:2,-4:0), na1a1crssscargqg(0:2,0:2,-4:0), na1a1crssscarqgg(0:2,0:2,-4:0), na1a1crssscarqqg(0:2,0:2,-
+     &4:0),
      5  na1a1sscarggg(0:2,0:2,-4:0), na1a1sscargqg(0:2,0:2,-4:0), na1a1sscarqgg(0:2,0:2,-4:0), na1a1sscarqqg(0:2,0:2,-4:0)
 
 	

--- a/src/hp_Intcts/hp_Iopmat2.f
+++ b/src/hp_Intcts/hp_Iopmat2.f
@@ -734,7 +734,8 @@ c     Accumulate the I20 operator which will be multiplied by the Born ME
                outarr(i,j,-1) = infunc(i,j)*logpower*xlrs
                outarr(i,j, 0) = infunc(i,j)*((logpower*xlrs)**2/2.0_ki + pisq/12.0_ki)
                outarr(i,j, 1) = infunc(i,j)*((logpower*xlrs)**3/6.0_ki + pisq/12.0_ki*(logpower*xlrs) + zeta3/3.0_ki)
-               outarr(i,j, 2) = infunc(i,j)*((logpower*xlrs)**4/24.0_ki + pisq/24.0_ki*(logpower*xlrs)**2 + (logpower*xlrs)*zeta3/3.0_ki + pisq**2/160.0_ki)
+               outarr(i,j, 2) = infunc(i,j)*((logpower*xlrs)**4/24.0_ki + pisq/24.0_ki*(logpower*xlrs)**2 + (logpower*xlrs)*zeta3/
+     &3.0_ki + pisq**2/160.0_ki)
             endif
          enddo
       enddo

--- a/src/hp_Intcts/include/hp_a12carscas_functions.h
+++ b/src/hp_Intcts/include/hp_a12carscas_functions.h
@@ -848,8 +848,10 @@
       l115 = hp_mylog(cone*(r1 + xa*xb))
       l116 = hp_mylog(cone*(r1 - im*r2*r3*(-1 + xb) + xa*xb))
       l117 = hp_mylog(cone*(r1 + im*r2*r3*(-1 + xb) + xa*xb))
-      l118 = hp_mylog(cone*(xa - xb - 2*r2*r3*r6*(-1 + xa)*(-1 + xb*(-1 + xa + xb)) + xb*(2*xa**3*xb + xb**2 + xa*(4 + (-4 + xb)*xb**2) + xa**2*(-3 + xb*(-4 + 3*xb)))))
-      l119 = hp_mylog(cone*(xa - xb + 2*r2*r3*r6*(-1 + xa)*(-1 + xb*(-1 + xa + xb)) + xb*(2*xa**3*xb + xb**2 + xa*(4 + (-4 + xb)*xb**2) + xa**2*(-3 + xb*(-4 + 3*xb)))))
+      l118 = hp_mylog(cone*(xa - xb - 2*r2*r3*r6*(-1 + xa)*(-1 + xb*(-1 + xa + xb)) + xb*(2*xa**3*xb + xb**2 + xa*(4 + (-4 + xb)
+     &*xb**2) + xa**2*(-3 + xb*(-4 + 3*xb)))))
+      l119 = hp_mylog(cone*(xa - xb + 2*r2*r3*r6*(-1 + xa)*(-1 + xb*(-1 + xa + xb)) + xb*(2*xa**3*xb + xb**2 + xa*(4 + (-4 + xb)
+     &*xb**2) + xa**2*(-3 + xb*(-4 + 3*xb)))))
       l120 = hp_mylog((cone*(r2 - r3*r4))/(-(r3*r4) + r2*xb))
       l121 = hp_mylog((cone*(r2/r3 + r4))/(r2*r3 + r4))
       l122 = hp_mylog((cone*(-(r2*r6) + r3*xa))/(r3 - r2*r6))
@@ -898,9 +900,12 @@
       l165 = hp_mylog((cone*((2*r12)/r20 + r7 - r15*r8 + r2*r3*(xa + xb)))/(r7 - r15*r8 + r2*r3*(xa + xb)))
       l166 = hp_mylog((cone*((-2*r11)/r19 + r7 + r15*r8 + r2*r3*(xa + xb)))/(r7 + r15*r8 + r2*r3*(xa + xb)))
       l167 = hp_mylog((cone*((-2*r12)/r20 + r7 + r15*r8 + r2*r3*(xa + xb)))/(r7 + r15*r8 + r2*r3*(xa + xb)))
-      l168 = hp_mylog(cone*(r1*(r5 + xb - r5*xb - xa*xb*(-1 + xa + xb)) - xb*(r5*(-1 + xb) + xa*(1 - 2*xb + xa*(-1 + xb*(xa + xb))))))
-      l169 = hp_mylog(cone*(r1*(r5*(-1 + xb) + xb - xa*xb*(-1 + xa + xb)) - xb*(r5 - r5*xb + xa*(1 - 2*xb + xa*(-1 + xb*(xa + xb))))))
-      l170 = hp_mylog((cone*(xa - xb + 2*r1*(-1 + xa)*(-1 + xb*(-1 + xa + xb)) + xb*(2*xa**3*xb + xb**2 + xa*(4 + (-4 + xb)*xb**2) + xa**2*(-3 + xb*(-4 + 3*xb)))))/((-1 + xb)*(1 + xb)*(xa + xb)*(-1 + xa*xb)))
+      l168 = hp_mylog(cone*(r1*(r5 + xb - r5*xb - xa*xb*(-1 + xa + xb)) - xb*(r5*(-1 + xb) + xa*(1 - 2*xb + xa*(-1 + xb*(xa + xb))))
+     &))
+      l169 = hp_mylog(cone*(r1*(r5*(-1 + xb) + xb - xa*xb*(-1 + xa + xb)) - xb*(r5 - r5*xb + xa*(1 - 2*xb + xa*(-1 + xb*(xa + xb))))
+     &))
+      l170 = hp_mylog((cone*(xa - xb + 2*r1*(-1 + xa)*(-1 + xb*(-1 + xa + xb)) + xb*(2*xa**3*xb + xb**2 + xa*(4 + (-4 + xb)*xb**2) +
+     & xa**2*(-3 + xb*(-4 + 3*xb)))))/((-1 + xb)*(1 + xb)*(xa + xb)*(-1 + xa*xb)))
       l171 = hp_mylog((cone*(-1 + xb)*(xa + xb))/(r1 - xa))
       l172 = hp_mylog(-((cone*r3*(-1 + xb)*(-(r2*r6) + r3*(1 + xa + xb)))/(r2*r3*r6*(-1 + xb) + 2*xa*xb - r1*(1 + xb))))
       l173 = hp_mylog((cone*(-1 + r3)*r3*(1 + r3)*(r2*r6 + r3*(1 + xa + xb)))/(r2*r3*r6*(-1 + xb) - 2*xa*xb + r1*(1 + xb)))
@@ -1030,10 +1035,14 @@
       g2 = hp_glog(czip,(cone*(r2 + r3*r4))/(r2 - r2*xb),cone)
       g3 = hp_glog(czip,-((cone*(r1 + xa))/((-1 + xb)*(xa + xb))),cone)
       g4 = hp_glog(czip,(cone*(r1 + xa*xb))/(xb - xb**2),cone)
-      g5 = hp_glog(czip,-((cone*(r1*(r5 + xb) + xb*(xa + r5*(-1 + xa + xb) - xa*(-1 + xb)*(xa + xb))))/((1 + xa)*(-1 + xb)*xb*(xa + xb))),cone)
-      g6 = hp_glog(czip,(cone*(r1*(r5 + xb) + xb*(xa + r5*(-1 + xa + xb) + xa*(-1 + xb)*(xa + xb))))/((-1 + xa)*(-1 + xb)*xb*(xa + xb)),cone)
-      g7 = hp_glog(czip,(cone*(r1*(r5 - xb) + xb*(-xa + r5*(-1 + xa + xb) + xa*(-1 + xb)*(xa + xb))))/((1 + xa)*(-1 + xb)*xb*(xa + xb)),cone)
-      g8 = hp_glog(czip,(cone*(r1*(-r5 + xb) + xb*(xa - r5*(-1 + xa + xb) + xa*(-1 + xb)*(xa + xb))))/((-1 + xa)*(-1 + xb)*xb*(xa + xb)),cone)
+      g5 = hp_glog(czip,-((cone*(r1*(r5 + xb) + xb*(xa + r5*(-1 + xa + xb) - xa*(-1 + xb)*(xa + xb))))/((1 + xa)*(-1 + xb)*xb*(xa + 
+     &xb))),cone)
+      g6 = hp_glog(czip,(cone*(r1*(r5 + xb) + xb*(xa + r5*(-1 + xa + xb) + xa*(-1 + xb)*(xa + xb))))/((-1 + xa)*(-1 + xb)*xb*(xa + 
+     &xb)),cone)
+      g7 = hp_glog(czip,(cone*(r1*(r5 - xb) + xb*(-xa + r5*(-1 + xa + xb) + xa*(-1 + xb)*(xa + xb))))/((1 + xa)*(-1 + xb)*xb*(xa + 
+     &xb)),cone)
+      g8 = hp_glog(czip,(cone*(r1*(-r5 + xb) + xb*(xa - r5*(-1 + xa + xb) + xa*(-1 + xb)*(xa + xb))))/((-1 + xa)*(-1 + xb)*xb*(xa + 
+     &xb)),cone)
       g9 = hp_glog((cone*(r2 - im*r3))/(r2 - r2*xb),czip,cone)
       g10 = hp_glog((cone*(r2 - im*r3))/(r2 - r2*xb),(cone*(1 + xb))/(1 - xb),cone)
       g11 = hp_glog((cone*(r2 - im*r3))/(r2 - r2*xb),(cone*(1 - xa))/(xa*(-1 + xb)),cone)
@@ -1111,33 +1120,53 @@
       g83 = hp_glog((cone*(r1 - xa*xb))/(xb - xa*xb),(cone*(1 + xa))/(-1 + xa),cone)
       g84 = hp_glog((cone*(r1 - xa*xb))/(xb - xa*xb),(cone*xa*(1 + xb))/((-1 + xa)*xb),cone)
       g85 = hp_glog((cone*((-im)*r1 + r2*r3*(-1 + xb) - im*xa*xb))/((r2 + im*r3)*r3*(-1 + xb)),cone,cone)
-      g86 = hp_glog((cone*((-im)*r1 + r2*r3*(-1 + xb) - im*xa*xb))/((r2 + im*r3)*r3*(-1 + xb)),-((cone*(r1 + xa))/((-1 + xb)*(xa + xb))),cone)
-      g87 = hp_glog((cone*((-im)*r1 + r2*r3*(-1 + xb) - im*xa*xb))/((r2 + im*r3)*r3*(-1 + xb)),(cone*(r1 + xa*xb))/(xb - xb**2),cone)
-      g88 = hp_glog((cone*((-im)*r1 + r2*r3*(-1 + xb) - im*xa*xb))/((r2 + im*r3)*r3*(-1 + xb)),-((cone*(r1*(r5 + xb) + xb*(xa + r5*(-1 + xa + xb) - xa*(-1 + xb)*(xa + xb))))/((1 + xa)*(-1 + xb)*xb*(xa + xb))),cone)
-      g89 = hp_glog((cone*((-im)*r1 + r2*r3*(-1 + xb) - im*xa*xb))/((r2 + im*r3)*r3*(-1 + xb)),(cone*(r1*(r5 + xb) + xb*(xa + r5*(-1 + xa + xb) + xa*(-1 + xb)*(xa + xb))))/((-1 + xa)*(-1 + xb)*xb*(xa + xb)),cone)
-      g90 = hp_glog((cone*((-im)*r1 + r2*r3*(-1 + xb) - im*xa*xb))/((r2 + im*r3)*r3*(-1 + xb)),(cone*(r1*(r5 - xb) + xb*(-xa + r5*(-1 + xa + xb) + xa*(-1 + xb)*(xa + xb))))/((1 + xa)*(-1 + xb)*xb*(xa + xb)),cone)
-      g91 = hp_glog((cone*((-im)*r1 + r2*r3*(-1 + xb) - im*xa*xb))/((r2 + im*r3)*r3*(-1 + xb)),(cone*(r1*(-r5 + xb) + xb*(xa - r5*(-1 + xa + xb) + xa*(-1 + xb)*(xa + xb))))/((-1 + xa)*(-1 + xb)*xb*(xa + xb)),cone)
+      g86 = hp_glog((cone*((-im)*r1 + r2*r3*(-1 + xb) - im*xa*xb))/((r2 + im*r3)*r3*(-1 + xb)),-((cone*(r1 + xa))/((-1 + xb)*(xa + 
+     &xb))),cone)
+      g87 = hp_glog((cone*((-im)*r1 + r2*r3*(-1 + xb) - im*xa*xb))/((r2 + im*r3)*r3*(-1 + xb)),(cone*(r1 + xa*xb))/(xb - xb**2),
+     &cone)
+      g88 = hp_glog((cone*((-im)*r1 + r2*r3*(-1 + xb) - im*xa*xb))/((r2 + im*r3)*r3*(-1 + xb)),-((cone*(r1*(r5 + xb) + xb*(xa + r5*(
+     &-1 + xa + xb) - xa*(-1 + xb)*(xa + xb))))/((1 + xa)*(-1 + xb)*xb*(xa + xb))),cone)
+      g89 = hp_glog((cone*((-im)*r1 + r2*r3*(-1 + xb) - im*xa*xb))/((r2 + im*r3)*r3*(-1 + xb)),(cone*(r1*(r5 + xb) + xb*(xa + r5*(-
+     &1 + xa + xb) + xa*(-1 + xb)*(xa + xb))))/((-1 + xa)*(-1 + xb)*xb*(xa + xb)),cone)
+      g90 = hp_glog((cone*((-im)*r1 + r2*r3*(-1 + xb) - im*xa*xb))/((r2 + im*r3)*r3*(-1 + xb)),(cone*(r1*(r5 - xb) + xb*(-xa + r5*(-
+     &1 + xa + xb) + xa*(-1 + xb)*(xa + xb))))/((1 + xa)*(-1 + xb)*xb*(xa + xb)),cone)
+      g91 = hp_glog((cone*((-im)*r1 + r2*r3*(-1 + xb) - im*xa*xb))/((r2 + im*r3)*r3*(-1 + xb)),(cone*(r1*(-r5 + xb) + xb*(xa - r5*(-
+     &1 + xa + xb) + xa*(-1 + xb)*(xa + xb))))/((-1 + xa)*(-1 + xb)*xb*(xa + xb)),cone)
       g92 = hp_glog((cone*(im*r1 + r2*r3*(-1 + xb) + im*xa*xb))/((r2 - im*r3)*r3*(-1 + r3**2)),cone,cone)
-      g93 = hp_glog((cone*(im*r1 + r2*r3*(-1 + xb) + im*xa*xb))/((r2 - im*r3)*r3*(-1 + r3**2)),-((cone*(r1 + xa))/((-1 + xb)*(xa + xb))),cone)
-      g94 = hp_glog((cone*(im*r1 + r2*r3*(-1 + xb) + im*xa*xb))/((r2 - im*r3)*r3*(-1 + r3**2)),(cone*(r1 + xa*xb))/(xb - xb**2),cone)
-      g95 = hp_glog((cone*(im*r1 + r2*r3*(-1 + xb) + im*xa*xb))/((r2 - im*r3)*r3*(-1 + r3**2)),-((cone*(r1*(r5 + xb) + xb*(xa + r5*(-1 + xa + xb) - xa*(-1 + xb)*(xa + xb))))/((1 + xa)*(-1 + xb)*xb*(xa + xb))),cone)
-      g96 = hp_glog((cone*(im*r1 + r2*r3*(-1 + xb) + im*xa*xb))/((r2 - im*r3)*r3*(-1 + r3**2)),(cone*(r1*(r5 + xb) + xb*(xa + r5*(-1 + xa + xb) + xa*(-1 + xb)*(xa + xb))))/((-1 + xa)*(-1 + xb)*xb*(xa + xb)),cone)
-      g97 = hp_glog((cone*(im*r1 + r2*r3*(-1 + xb) + im*xa*xb))/((r2 - im*r3)*r3*(-1 + r3**2)),(cone*(r1*(r5 - xb) + xb*(-xa + r5*(-1 + xa + xb) + xa*(-1 + xb)*(xa + xb))))/((1 + xa)*(-1 + xb)*xb*(xa + xb)),cone)
-      g98 = hp_glog((cone*(im*r1 + r2*r3*(-1 + xb) + im*xa*xb))/((r2 - im*r3)*r3*(-1 + r3**2)),(cone*(r1*(-r5 + xb) + xb*(xa - r5*(-1 + xa + xb) + xa*(-1 + xb)*(xa + xb))))/((-1 + xa)*(-1 + xb)*xb*(xa + xb)),cone)
+      g93 = hp_glog((cone*(im*r1 + r2*r3*(-1 + xb) + im*xa*xb))/((r2 - im*r3)*r3*(-1 + r3**2)),-((cone*(r1 + xa))/((-1 + xb)*(xa + 
+     &xb))),cone)
+      g94 = hp_glog((cone*(im*r1 + r2*r3*(-1 + xb) + im*xa*xb))/((r2 - im*r3)*r3*(-1 + r3**2)),(cone*(r1 + xa*xb))/(xb - xb**2),
+     &cone)
+      g95 = hp_glog((cone*(im*r1 + r2*r3*(-1 + xb) + im*xa*xb))/((r2 - im*r3)*r3*(-1 + r3**2)),-((cone*(r1*(r5 + xb) + xb*(xa + r5*(
+     &-1 + xa + xb) - xa*(-1 + xb)*(xa + xb))))/((1 + xa)*(-1 + xb)*xb*(xa + xb))),cone)
+      g96 = hp_glog((cone*(im*r1 + r2*r3*(-1 + xb) + im*xa*xb))/((r2 - im*r3)*r3*(-1 + r3**2)),(cone*(r1*(r5 + xb) + xb*(xa + r5*(-
+     &1 + xa + xb) + xa*(-1 + xb)*(xa + xb))))/((-1 + xa)*(-1 + xb)*xb*(xa + xb)),cone)
+      g97 = hp_glog((cone*(im*r1 + r2*r3*(-1 + xb) + im*xa*xb))/((r2 - im*r3)*r3*(-1 + r3**2)),(cone*(r1*(r5 - xb) + xb*(-xa + r5*(-
+     &1 + xa + xb) + xa*(-1 + xb)*(xa + xb))))/((1 + xa)*(-1 + xb)*xb*(xa + xb)),cone)
+      g98 = hp_glog((cone*(im*r1 + r2*r3*(-1 + xb) + im*xa*xb))/((r2 - im*r3)*r3*(-1 + r3**2)),(cone*(r1*(-r5 + xb) + xb*(xa - r5*(-
+     &1 + xa + xb) + xa*(-1 + xb)*(xa + xb))))/((-1 + xa)*(-1 + xb)*xb*(xa + xb)),cone)
       g99 = hp_glog(-((cone*(r1 + xa))/((-1 + xb)*(xa + xb))),cone,cone)
       g100 = hp_glog(-((cone*(r1 + xa))/((-1 + xb)*(xa + xb))),-((cone*(r1 + xa))/((-1 + xb)*(xa + xb))),cone)
       g101 = hp_glog(-((cone*(r1 + xa))/((-1 + xb)*(xa + xb))),(cone*(r1 + xa*xb))/(xb - xb**2),cone)
-      g102 = hp_glog(-((cone*(r1 + xa))/((-1 + xb)*(xa + xb))),-((cone*(r1*(r5 + xb) + xb*(xa + r5*(-1 + xa + xb) - xa*(-1 + xb)*(xa + xb))))/((1 + xa)*(-1 + xb)*xb*(xa + xb))),cone)
-      g103 = hp_glog(-((cone*(r1 + xa))/((-1 + xb)*(xa + xb))),(cone*(r1*(r5 + xb) + xb*(xa + r5*(-1 + xa + xb) + xa*(-1 + xb)*(xa + xb))))/((-1 + xa)*(-1 + xb)*xb*(xa + xb)),cone)
-      g104 = hp_glog(-((cone*(r1 + xa))/((-1 + xb)*(xa + xb))),(cone*(r1*(r5 - xb) + xb*(-xa + r5*(-1 + xa + xb) + xa*(-1 + xb)*(xa + xb))))/((1 + xa)*(-1 + xb)*xb*(xa + xb)),cone)
-      g105 = hp_glog(-((cone*(r1 + xa))/((-1 + xb)*(xa + xb))),(cone*(r1*(-r5 + xb) + xb*(xa - r5*(-1 + xa + xb) + xa*(-1 + xb)*(xa + xb))))/((-1 + xa)*(-1 + xb)*xb*(xa + xb)),cone)
+      g102 = hp_glog(-((cone*(r1 + xa))/((-1 + xb)*(xa + xb))),-((cone*(r1*(r5 + xb) + xb*(xa + r5*(-1 + xa + xb) - xa*(-1 + xb)*(
+     &xa + xb))))/((1 + xa)*(-1 + xb)*xb*(xa + xb))),cone)
+      g103 = hp_glog(-((cone*(r1 + xa))/((-1 + xb)*(xa + xb))),(cone*(r1*(r5 + xb) + xb*(xa + r5*(-1 + xa + xb) + xa*(-1 + xb)*(xa +
+     & xb))))/((-1 + xa)*(-1 + xb)*xb*(xa + xb)),cone)
+      g104 = hp_glog(-((cone*(r1 + xa))/((-1 + xb)*(xa + xb))),(cone*(r1*(r5 - xb) + xb*(-xa + r5*(-1 + xa + xb) + xa*(-1 + xb)*(xa 
+     &+ xb))))/((1 + xa)*(-1 + xb)*xb*(xa + xb)),cone)
+      g105 = hp_glog(-((cone*(r1 + xa))/((-1 + xb)*(xa + xb))),(cone*(r1*(-r5 + xb) + xb*(xa - r5*(-1 + xa + xb) + xa*(-1 + xb)*(xa 
+     &+ xb))))/((-1 + xa)*(-1 + xb)*xb*(xa + xb)),cone)
       g106 = hp_glog((-2*cone*(r1 + xa))/((xa + xb)*(-1 + xb**2)),cone,cone)
       g107 = hp_glog((-2*cone*(r1 + xa))/((xa + xb)*(-1 + xb**2)),-((cone*(r1 + xa))/((-1 + xb)*(xa + xb))),cone)
       g108 = hp_glog((-2*cone*(r1 + xa))/((xa + xb)*(-1 + xb**2)),(cone*(r1 + xa*xb))/(xb - xb**2),cone)
-      g109 = hp_glog((-2*cone*(r1 + xa))/((xa + xb)*(-1 + xb**2)),-((cone*(r1*(r5 + xb) + xb*(xa + r5*(-1 + xa + xb) - xa*(-1 + xb)*(xa + xb))))/((1 + xa)*(-1 + xb)*xb*(xa + xb))),cone)
-      g110 = hp_glog((-2*cone*(r1 + xa))/((xa + xb)*(-1 + xb**2)),(cone*(r1*(r5 + xb) + xb*(xa + r5*(-1 + xa + xb) + xa*(-1 + xb)*(xa + xb))))/((-1 + xa)*(-1 + xb)*xb*(xa + xb)),cone)
-      g111 = hp_glog((-2*cone*(r1 + xa))/((xa + xb)*(-1 + xb**2)),(cone*(r1*(r5 - xb) + xb*(-xa + r5*(-1 + xa + xb) + xa*(-1 + xb)*(xa + xb))))/((1 + xa)*(-1 + xb)*xb*(xa + xb)),cone)
-      g112 = hp_glog((-2*cone*(r1 + xa))/((xa + xb)*(-1 + xb**2)),(cone*(r1*(-r5 + xb) + xb*(xa - r5*(-1 + xa + xb) + xa*(-1 + xb)*(xa + xb))))/((-1 + xa)*(-1 + xb)*xb*(xa + xb)),cone)
+      g109 = hp_glog((-2*cone*(r1 + xa))/((xa + xb)*(-1 + xb**2)),-((cone*(r1*(r5 + xb) + xb*(xa + r5*(-1 + xa + xb) - xa*(-1 + xb)
+     &*(xa + xb))))/((1 + xa)*(-1 + xb)*xb*(xa + xb))),cone)
+      g110 = hp_glog((-2*cone*(r1 + xa))/((xa + xb)*(-1 + xb**2)),(cone*(r1*(r5 + xb) + xb*(xa + r5*(-1 + xa + xb) + xa*(-1 + xb)*(
+     &xa + xb))))/((-1 + xa)*(-1 + xb)*xb*(xa + xb)),cone)
+      g111 = hp_glog((-2*cone*(r1 + xa))/((xa + xb)*(-1 + xb**2)),(cone*(r1*(r5 - xb) + xb*(-xa + r5*(-1 + xa + xb) + xa*(-1 + xb)*(
+     &xa + xb))))/((1 + xa)*(-1 + xb)*xb*(xa + xb)),cone)
+      g112 = hp_glog((-2*cone*(r1 + xa))/((xa + xb)*(-1 + xb**2)),(cone*(r1*(-r5 + xb) + xb*(xa - r5*(-1 + xa + xb) + xa*(-1 + xb)*(
+     &xa + xb))))/((-1 + xa)*(-1 + xb)*xb*(xa + xb)),cone)
       g113 = hp_glog(-((cone*(r1 + xb))/(xb*(-2 + xa + xb))),cone,cone)
       g114 = hp_glog((cone*(r1 + xa*xb))/((-1 + xa)*xb),czip,cone)
       g115 = hp_glog((cone*(r1 + xa*xb))/((-1 + xa)*xb),cone,cone)
@@ -1148,82 +1177,137 @@
       g120 = hp_glog((cone*(r1 + xa*xb))/(xb - xb**2),cone,cone)
       g121 = hp_glog((cone*(r1 + xa*xb))/(xb - xb**2),-((cone*(r1 + xa))/((-1 + xb)*(xa + xb))),cone)
       g122 = hp_glog((cone*(r1 + xa*xb))/(xb - xb**2),(cone*(r1 + xa*xb))/(xb - xb**2),cone)
-      g123 = hp_glog((cone*(r1 + xa*xb))/(xb - xb**2),-((cone*(r1*(r5 + xb) + xb*(xa + r5*(-1 + xa + xb) - xa*(-1 + xb)*(xa + xb))))/((1 + xa)*(-1 + xb)*xb*(xa + xb))),cone)
-      g124 = hp_glog((cone*(r1 + xa*xb))/(xb - xb**2),(cone*(r1*(r5 + xb) + xb*(xa + r5*(-1 + xa + xb) + xa*(-1 + xb)*(xa + xb))))/((-1 + xa)*(-1 + xb)*xb*(xa + xb)),cone)
-      g125 = hp_glog((cone*(r1 + xa*xb))/(xb - xb**2),(cone*(r1*(r5 - xb) + xb*(-xa + r5*(-1 + xa + xb) + xa*(-1 + xb)*(xa + xb))))/((1 + xa)*(-1 + xb)*xb*(xa + xb)),cone)
-      g126 = hp_glog((cone*(r1 + xa*xb))/(xb - xb**2),(cone*(r1*(-r5 + xb) + xb*(xa - r5*(-1 + xa + xb) + xa*(-1 + xb)*(xa + xb))))/((-1 + xa)*(-1 + xb)*xb*(xa + xb)),cone)
+      g123 = hp_glog((cone*(r1 + xa*xb))/(xb - xb**2),-((cone*(r1*(r5 + xb) + xb*(xa + r5*(-1 + xa + xb) - xa*(-1 + xb)*(xa + xb))))
+     &/((1 + xa)*(-1 + xb)*xb*(xa + xb))),cone)
+      g124 = hp_glog((cone*(r1 + xa*xb))/(xb - xb**2),(cone*(r1*(r5 + xb) + xb*(xa + r5*(-1 + xa + xb) + xa*(-1 + xb)*(xa + xb))))/(
+     &(-1 + xa)*(-1 + xb)*xb*(xa + xb)),cone)
+      g125 = hp_glog((cone*(r1 + xa*xb))/(xb - xb**2),(cone*(r1*(r5 - xb) + xb*(-xa + r5*(-1 + xa + xb) + xa*(-1 + xb)*(xa + xb))))/
+     &((1 + xa)*(-1 + xb)*xb*(xa + xb)),cone)
+      g126 = hp_glog((cone*(r1 + xa*xb))/(xb - xb**2),(cone*(r1*(-r5 + xb) + xb*(xa - r5*(-1 + xa + xb) + xa*(-1 + xb)*(xa + xb))))/
+     &((-1 + xa)*(-1 + xb)*xb*(xa + xb)),cone)
       g127 = hp_glog((-2*cone*(r1 + xa*xb))/(-1 + xb**2),cone,cone)
       g128 = hp_glog((-2*cone*(r1 + xa*xb))/(-1 + xb**2),-((cone*(r1 + xa))/((-1 + xb)*(xa + xb))),cone)
       g129 = hp_glog((-2*cone*(r1 + xa*xb))/(-1 + xb**2),(cone*(r1 + xa*xb))/(xb - xb**2),cone)
-      g130 = hp_glog((-2*cone*(r1 + xa*xb))/(-1 + xb**2),-((cone*(r1*(r5 + xb) + xb*(xa + r5*(-1 + xa + xb) - xa*(-1 + xb)*(xa + xb))))/((1 + xa)*(-1 + xb)*xb*(xa + xb))),cone)
-      g131 = hp_glog((-2*cone*(r1 + xa*xb))/(-1 + xb**2),(cone*(r1*(r5 + xb) + xb*(xa + r5*(-1 + xa + xb) + xa*(-1 + xb)*(xa + xb))))/((-1 + xa)*(-1 + xb)*xb*(xa + xb)),cone)
-      g132 = hp_glog((-2*cone*(r1 + xa*xb))/(-1 + xb**2),(cone*(r1*(r5 - xb) + xb*(-xa + r5*(-1 + xa + xb) + xa*(-1 + xb)*(xa + xb))))/((1 + xa)*(-1 + xb)*xb*(xa + xb)),cone)
-      g133 = hp_glog((-2*cone*(r1 + xa*xb))/(-1 + xb**2),(cone*(r1*(-r5 + xb) + xb*(xa - r5*(-1 + xa + xb) + xa*(-1 + xb)*(xa + xb))))/((-1 + xa)*(-1 + xb)*xb*(xa + xb)),cone)
+      g130 = hp_glog((-2*cone*(r1 + xa*xb))/(-1 + xb**2),-((cone*(r1*(r5 + xb) + xb*(xa + r5*(-1 + xa + xb) - xa*(-1 + xb)*(xa + xb)
+     &)))/((1 + xa)*(-1 + xb)*xb*(xa + xb))),cone)
+      g131 = hp_glog((-2*cone*(r1 + xa*xb))/(-1 + xb**2),(cone*(r1*(r5 + xb) + xb*(xa + r5*(-1 + xa + xb) + xa*(-1 + xb)*(xa + xb)))
+     &)/((-1 + xa)*(-1 + xb)*xb*(xa + xb)),cone)
+      g132 = hp_glog((-2*cone*(r1 + xa*xb))/(-1 + xb**2),(cone*(r1*(r5 - xb) + xb*(-xa + r5*(-1 + xa + xb) + xa*(-1 + xb)*(xa + xb))
+     &))/((1 + xa)*(-1 + xb)*xb*(xa + xb)),cone)
+      g133 = hp_glog((-2*cone*(r1 + xa*xb))/(-1 + xb**2),(cone*(r1*(-r5 + xb) + xb*(xa - r5*(-1 + xa + xb) + xa*(-1 + xb)*(xa + xb))
+     &))/((-1 + xa)*(-1 + xb)*xb*(xa + xb)),cone)
       g134 = hp_glog((cone*(r1 - xa))/(r1 - xb*(-1 + xa + xb)),cone,cone)
       g135 = hp_glog((cone*(r1 - xa))/(r1 - xb*(-1 + xa + xb)),(cone*(r1 - xa))/(r1 - xb*(-1 + xa + xb)),cone)
       g136 = hp_glog((cone*(r1 - xa))/(r1 - xb*(-1 + xa + xb)),(cone*(r1 - xa*xb))/(r1 - xb*(-1 + xa + xb)),cone)
-      g137 = hp_glog((cone*(r1 - xa))/(r1 - xb*(-1 + xa + xb)),(cone*(-(r1*(1 + xa)) - r2*r3*r4*(-1 + xb) + xa*xb*(xa + xb)))/((1 + xa)*(-r1 + xb*(-1 + xa + xb))),cone)
-      g138 = hp_glog((cone*(r1 - xa))/(r1 - xb*(-1 + xa + xb)),(cone*(-(r1*(1 + xa)) + r2*r3*r4*(-1 + xb) + xa*xb*(xa + xb)))/((1 + xa)*(-r1 + xb*(-1 + xa + xb))),cone)
-      g139 = hp_glog((cone*(r1 - xa))/(r1 - xb*(-1 + xa + xb)),(cone*(r1 - r1*xa - r2*r3*r4*(-1 + xb) + xa*xb*(-2 + xa + xb)))/((-1 + xa)*(-r1 + xb*(-1 + xa + xb))),cone)
-      g140 = hp_glog((cone*(r1 - xa))/(r1 - xb*(-1 + xa + xb)),(cone*(r1 - r1*xa + r2*r3*r4*(-1 + xb) + xa*xb*(-2 + xa + xb)))/((-1 + xa)*(-r1 + xb*(-1 + xa + xb))),cone)
+      g137 = hp_glog((cone*(r1 - xa))/(r1 - xb*(-1 + xa + xb)),(cone*(-(r1*(1 + xa)) - r2*r3*r4*(-1 + xb) + xa*xb*(xa + xb)))/((1 + 
+     &xa)*(-r1 + xb*(-1 + xa + xb))),cone)
+      g138 = hp_glog((cone*(r1 - xa))/(r1 - xb*(-1 + xa + xb)),(cone*(-(r1*(1 + xa)) + r2*r3*r4*(-1 + xb) + xa*xb*(xa + xb)))/((1 + 
+     &xa)*(-r1 + xb*(-1 + xa + xb))),cone)
+      g139 = hp_glog((cone*(r1 - xa))/(r1 - xb*(-1 + xa + xb)),(cone*(r1 - r1*xa - r2*r3*r4*(-1 + xb) + xa*xb*(-2 + xa + xb)))/((-1 
+     &+ xa)*(-r1 + xb*(-1 + xa + xb))),cone)
+      g140 = hp_glog((cone*(r1 - xa))/(r1 - xb*(-1 + xa + xb)),(cone*(r1 - r1*xa + r2*r3*r4*(-1 + xb) + xa*xb*(-2 + xa + xb)))/((-1 
+     &+ xa)*(-r1 + xb*(-1 + xa + xb))),cone)
       g141 = hp_glog((cone*(r1 - xb))/(r1 - xb*(-1 + xa + xb)),cone,cone)
       g142 = hp_glog((cone*(r1 - xa*xb))/(r1 - xb*(-1 + xa + xb)),cone,cone)
       g143 = hp_glog((cone*(r1 - xa*xb))/(r1 - xb*(-1 + xa + xb)),(cone*(r1 - xa))/(r1 - xb*(-1 + xa + xb)),cone)
       g144 = hp_glog((cone*(r1 - xa*xb))/(r1 - xb*(-1 + xa + xb)),(cone*(r1 - xa*xb))/(r1 - xb*(-1 + xa + xb)),cone)
-      g145 = hp_glog((cone*(r1 - xa*xb))/(r1 - xb*(-1 + xa + xb)),(cone*(-(r1*(1 + xa)) - r2*r3*r4*(-1 + xb) + xa*xb*(xa + xb)))/((1 + xa)*(-r1 + xb*(-1 + xa + xb))),cone)
-      g146 = hp_glog((cone*(r1 - xa*xb))/(r1 - xb*(-1 + xa + xb)),(cone*(-(r1*(1 + xa)) + r2*r3*r4*(-1 + xb) + xa*xb*(xa + xb)))/((1 + xa)*(-r1 + xb*(-1 + xa + xb))),cone)
-      g147 = hp_glog((cone*(r1 - xa*xb))/(r1 - xb*(-1 + xa + xb)),(cone*(r1 - r1*xa - r2*r3*r4*(-1 + xb) + xa*xb*(-2 + xa + xb)))/((-1 + xa)*(-r1 + xb*(-1 + xa + xb))),cone)
-      g148 = hp_glog((cone*(r1 - xa*xb))/(r1 - xb*(-1 + xa + xb)),(cone*(r1 - r1*xa + r2*r3*r4*(-1 + xb) + xa*xb*(-2 + xa + xb)))/((-1 + xa)*(-r1 + xb*(-1 + xa + xb))),cone)
+      g145 = hp_glog((cone*(r1 - xa*xb))/(r1 - xb*(-1 + xa + xb)),(cone*(-(r1*(1 + xa)) - r2*r3*r4*(-1 + xb) + xa*xb*(xa + xb)))/((
+     &1 + xa)*(-r1 + xb*(-1 + xa + xb))),cone)
+      g146 = hp_glog((cone*(r1 - xa*xb))/(r1 - xb*(-1 + xa + xb)),(cone*(-(r1*(1 + xa)) + r2*r3*r4*(-1 + xb) + xa*xb*(xa + xb)))/((
+     &1 + xa)*(-r1 + xb*(-1 + xa + xb))),cone)
+      g147 = hp_glog((cone*(r1 - xa*xb))/(r1 - xb*(-1 + xa + xb)),(cone*(r1 - r1*xa - r2*r3*r4*(-1 + xb) + xa*xb*(-2 + xa + xb)))/((
+     &-1 + xa)*(-r1 + xb*(-1 + xa + xb))),cone)
+      g148 = hp_glog((cone*(r1 - xa*xb))/(r1 - xb*(-1 + xa + xb)),(cone*(r1 - r1*xa + r2*r3*r4*(-1 + xb) + xa*xb*(-2 + xa + xb)))/((
+     &-1 + xa)*(-r1 + xb*(-1 + xa + xb))),cone)
       g149 = hp_glog((cone*(r1 - im*r2*r3*(-1 + xb) - xa*xb))/(r1 - xb*(-1 + xa + xb)),cone,cone)
-      g150 = hp_glog((cone*(r1 - im*r2*r3*(-1 + xb) - xa*xb))/(r1 - xb*(-1 + xa + xb)),(cone*(r1 - xa))/(r1 - xb*(-1 + xa + xb)),cone)
-      g151 = hp_glog((cone*(r1 - im*r2*r3*(-1 + xb) - xa*xb))/(r1 - xb*(-1 + xa + xb)),(cone*(r1 - xa*xb))/(r1 - xb*(-1 + xa + xb)),cone)
-      g152 = hp_glog((cone*(r1 - im*r2*r3*(-1 + xb) - xa*xb))/(r1 - xb*(-1 + xa + xb)),(cone*(-(r1*(1 + xa)) - r2*r3*r4*(-1 + xb) + xa*xb*(xa + xb)))/((1 + xa)*(-r1 + xb*(-1 + xa + xb))),cone)
-      g153 = hp_glog((cone*(r1 - im*r2*r3*(-1 + xb) - xa*xb))/(r1 - xb*(-1 + xa + xb)),(cone*(-(r1*(1 + xa)) + r2*r3*r4*(-1 + xb) + xa*xb*(xa + xb)))/((1 + xa)*(-r1 + xb*(-1 + xa + xb))),cone)
-      g154 = hp_glog((cone*(r1 - im*r2*r3*(-1 + xb) - xa*xb))/(r1 - xb*(-1 + xa + xb)),(cone*(r1 - r1*xa - r2*r3*r4*(-1 + xb) + xa*xb*(-2 + xa + xb)))/((-1 + xa)*(-r1 + xb*(-1 + xa + xb))),cone)
-      g155 = hp_glog((cone*(r1 - im*r2*r3*(-1 + xb) - xa*xb))/(r1 - xb*(-1 + xa + xb)),(cone*(r1 - r1*xa + r2*r3*r4*(-1 + xb) + xa*xb*(-2 + xa + xb)))/((-1 + xa)*(-r1 + xb*(-1 + xa + xb))),cone)
+      g150 = hp_glog((cone*(r1 - im*r2*r3*(-1 + xb) - xa*xb))/(r1 - xb*(-1 + xa + xb)),(cone*(r1 - xa))/(r1 - xb*(-1 + xa + xb)),
+     &cone)
+      g151 = hp_glog((cone*(r1 - im*r2*r3*(-1 + xb) - xa*xb))/(r1 - xb*(-1 + xa + xb)),(cone*(r1 - xa*xb))/(r1 - xb*(-1 + xa + xb)),
+     &cone)
+      g152 = hp_glog((cone*(r1 - im*r2*r3*(-1 + xb) - xa*xb))/(r1 - xb*(-1 + xa + xb)),(cone*(-(r1*(1 + xa)) - r2*r3*r4*(-1 + xb) + 
+     &xa*xb*(xa + xb)))/((1 + xa)*(-r1 + xb*(-1 + xa + xb))),cone)
+      g153 = hp_glog((cone*(r1 - im*r2*r3*(-1 + xb) - xa*xb))/(r1 - xb*(-1 + xa + xb)),(cone*(-(r1*(1 + xa)) + r2*r3*r4*(-1 + xb) + 
+     &xa*xb*(xa + xb)))/((1 + xa)*(-r1 + xb*(-1 + xa + xb))),cone)
+      g154 = hp_glog((cone*(r1 - im*r2*r3*(-1 + xb) - xa*xb))/(r1 - xb*(-1 + xa + xb)),(cone*(r1 - r1*xa - r2*r3*r4*(-1 + xb) + 
+     &xa*xb*(-2 + xa + xb)))/((-1 + xa)*(-r1 + xb*(-1 + xa + xb))),cone)
+      g155 = hp_glog((cone*(r1 - im*r2*r3*(-1 + xb) - xa*xb))/(r1 - xb*(-1 + xa + xb)),(cone*(r1 - r1*xa + r2*r3*r4*(-1 + xb) + 
+     &xa*xb*(-2 + xa + xb)))/((-1 + xa)*(-r1 + xb*(-1 + xa + xb))),cone)
       g156 = hp_glog((cone*(r1 + im*r2*r3*(-1 + xb) - xa*xb))/(r1 - xb*(-1 + xa + xb)),cone,cone)
-      g157 = hp_glog((cone*(r1 + im*r2*r3*(-1 + xb) - xa*xb))/(r1 - xb*(-1 + xa + xb)),(cone*(r1 - xa))/(r1 - xb*(-1 + xa + xb)),cone)
-      g158 = hp_glog((cone*(r1 + im*r2*r3*(-1 + xb) - xa*xb))/(r1 - xb*(-1 + xa + xb)),(cone*(r1 - xa*xb))/(r1 - xb*(-1 + xa + xb)),cone)
-      g159 = hp_glog((cone*(r1 + im*r2*r3*(-1 + xb) - xa*xb))/(r1 - xb*(-1 + xa + xb)),(cone*(-(r1*(1 + xa)) - r2*r3*r4*(-1 + xb) + xa*xb*(xa + xb)))/((1 + xa)*(-r1 + xb*(-1 + xa + xb))),cone)
-      g160 = hp_glog((cone*(r1 + im*r2*r3*(-1 + xb) - xa*xb))/(r1 - xb*(-1 + xa + xb)),(cone*(-(r1*(1 + xa)) + r2*r3*r4*(-1 + xb) + xa*xb*(xa + xb)))/((1 + xa)*(-r1 + xb*(-1 + xa + xb))),cone)
-      g161 = hp_glog((cone*(r1 + im*r2*r3*(-1 + xb) - xa*xb))/(r1 - xb*(-1 + xa + xb)),(cone*(r1 - r1*xa - r2*r3*r4*(-1 + xb) + xa*xb*(-2 + xa + xb)))/((-1 + xa)*(-r1 + xb*(-1 + xa + xb))),cone)
-      g162 = hp_glog((cone*(r1 + im*r2*r3*(-1 + xb) - xa*xb))/(r1 - xb*(-1 + xa + xb)),(cone*(r1 - r1*xa + r2*r3*r4*(-1 + xb) + xa*xb*(-2 + xa + xb)))/((-1 + xa)*(-r1 + xb*(-1 + xa + xb))),cone)
+      g157 = hp_glog((cone*(r1 + im*r2*r3*(-1 + xb) - xa*xb))/(r1 - xb*(-1 + xa + xb)),(cone*(r1 - xa))/(r1 - xb*(-1 + xa + xb)),
+     &cone)
+      g158 = hp_glog((cone*(r1 + im*r2*r3*(-1 + xb) - xa*xb))/(r1 - xb*(-1 + xa + xb)),(cone*(r1 - xa*xb))/(r1 - xb*(-1 + xa + xb)),
+     &cone)
+      g159 = hp_glog((cone*(r1 + im*r2*r3*(-1 + xb) - xa*xb))/(r1 - xb*(-1 + xa + xb)),(cone*(-(r1*(1 + xa)) - r2*r3*r4*(-1 + xb) + 
+     &xa*xb*(xa + xb)))/((1 + xa)*(-r1 + xb*(-1 + xa + xb))),cone)
+      g160 = hp_glog((cone*(r1 + im*r2*r3*(-1 + xb) - xa*xb))/(r1 - xb*(-1 + xa + xb)),(cone*(-(r1*(1 + xa)) + r2*r3*r4*(-1 + xb) + 
+     &xa*xb*(xa + xb)))/((1 + xa)*(-r1 + xb*(-1 + xa + xb))),cone)
+      g161 = hp_glog((cone*(r1 + im*r2*r3*(-1 + xb) - xa*xb))/(r1 - xb*(-1 + xa + xb)),(cone*(r1 - r1*xa - r2*r3*r4*(-1 + xb) + 
+     &xa*xb*(-2 + xa + xb)))/((-1 + xa)*(-r1 + xb*(-1 + xa + xb))),cone)
+      g162 = hp_glog((cone*(r1 + im*r2*r3*(-1 + xb) - xa*xb))/(r1 - xb*(-1 + xa + xb)),(cone*(r1 - r1*xa + r2*r3*r4*(-1 + xb) + 
+     &xa*xb*(-2 + xa + xb)))/((-1 + xa)*(-r1 + xb*(-1 + xa + xb))),cone)
       g163 = hp_glog((cone*(r1 - r2*r3*r6))/(r1 - xb*(-1 + xa + xb)),cone,cone)
       g164 = hp_glog((cone*(r1 - r2*r3*r6))/(r1 - xb*(-1 + xa + xb)),(cone*(r1 - xa))/(r1 - xb*(-1 + xa + xb)),cone)
       g165 = hp_glog((cone*(r1 - r2*r3*r6))/(r1 - xb*(-1 + xa + xb)),(cone*(r1 - xa*xb))/(r1 - xb*(-1 + xa + xb)),cone)
-      g166 = hp_glog((cone*(r1 - r2*r3*r6))/(r1 - xb*(-1 + xa + xb)),(cone*(-(r1*(1 + xa)) - r2*r3*r4*(-1 + xb) + xa*xb*(xa + xb)))/((1 + xa)*(-r1 + xb*(-1 + xa + xb))),cone)
-      g167 = hp_glog((cone*(r1 - r2*r3*r6))/(r1 - xb*(-1 + xa + xb)),(cone*(-(r1*(1 + xa)) + r2*r3*r4*(-1 + xb) + xa*xb*(xa + xb)))/((1 + xa)*(-r1 + xb*(-1 + xa + xb))),cone)
-      g168 = hp_glog((cone*(r1 - r2*r3*r6))/(r1 - xb*(-1 + xa + xb)),(cone*(r1 - r1*xa - r2*r3*r4*(-1 + xb) + xa*xb*(-2 + xa + xb)))/((-1 + xa)*(-r1 + xb*(-1 + xa + xb))),cone)
-      g169 = hp_glog((cone*(r1 - r2*r3*r6))/(r1 - xb*(-1 + xa + xb)),(cone*(r1 - r1*xa + r2*r3*r4*(-1 + xb) + xa*xb*(-2 + xa + xb)))/((-1 + xa)*(-r1 + xb*(-1 + xa + xb))),cone)
+      g166 = hp_glog((cone*(r1 - r2*r3*r6))/(r1 - xb*(-1 + xa + xb)),(cone*(-(r1*(1 + xa)) - r2*r3*r4*(-1 + xb) + xa*xb*(xa + xb)))/
+     &((1 + xa)*(-r1 + xb*(-1 + xa + xb))),cone)
+      g167 = hp_glog((cone*(r1 - r2*r3*r6))/(r1 - xb*(-1 + xa + xb)),(cone*(-(r1*(1 + xa)) + r2*r3*r4*(-1 + xb) + xa*xb*(xa + xb)))/
+     &((1 + xa)*(-r1 + xb*(-1 + xa + xb))),cone)
+      g168 = hp_glog((cone*(r1 - r2*r3*r6))/(r1 - xb*(-1 + xa + xb)),(cone*(r1 - r1*xa - r2*r3*r4*(-1 + xb) + xa*xb*(-2 + xa + xb)))
+     &/((-1 + xa)*(-r1 + xb*(-1 + xa + xb))),cone)
+      g169 = hp_glog((cone*(r1 - r2*r3*r6))/(r1 - xb*(-1 + xa + xb)),(cone*(r1 - r1*xa + r2*r3*r4*(-1 + xb) + xa*xb*(-2 + xa + xb)))
+     &/((-1 + xa)*(-r1 + xb*(-1 + xa + xb))),cone)
       g170 = hp_glog((cone*(r1 + r2*r3*r6))/(r1 - xb*(-1 + xa + xb)),cone,cone)
       g171 = hp_glog((cone*(r1 + r2*r3*r6))/(r1 - xb*(-1 + xa + xb)),(cone*(r1 - xa))/(r1 - xb*(-1 + xa + xb)),cone)
       g172 = hp_glog((cone*(r1 + r2*r3*r6))/(r1 - xb*(-1 + xa + xb)),(cone*(r1 - xa*xb))/(r1 - xb*(-1 + xa + xb)),cone)
-      g173 = hp_glog((cone*(r1 + r2*r3*r6))/(r1 - xb*(-1 + xa + xb)),(cone*(-(r1*(1 + xa)) - r2*r3*r4*(-1 + xb) + xa*xb*(xa + xb)))/((1 + xa)*(-r1 + xb*(-1 + xa + xb))),cone)
-      g174 = hp_glog((cone*(r1 + r2*r3*r6))/(r1 - xb*(-1 + xa + xb)),(cone*(-(r1*(1 + xa)) + r2*r3*r4*(-1 + xb) + xa*xb*(xa + xb)))/((1 + xa)*(-r1 + xb*(-1 + xa + xb))),cone)
-      g175 = hp_glog((cone*(r1 + r2*r3*r6))/(r1 - xb*(-1 + xa + xb)),(cone*(r1 - r1*xa - r2*r3*r4*(-1 + xb) + xa*xb*(-2 + xa + xb)))/((-1 + xa)*(-r1 + xb*(-1 + xa + xb))),cone)
-      g176 = hp_glog((cone*(r1 + r2*r3*r6))/(r1 - xb*(-1 + xa + xb)),(cone*(r1 - r1*xa + r2*r3*r4*(-1 + xb) + xa*xb*(-2 + xa + xb)))/((-1 + xa)*(-r1 + xb*(-1 + xa + xb))),cone)
+      g173 = hp_glog((cone*(r1 + r2*r3*r6))/(r1 - xb*(-1 + xa + xb)),(cone*(-(r1*(1 + xa)) - r2*r3*r4*(-1 + xb) + xa*xb*(xa + xb)))/
+     &((1 + xa)*(-r1 + xb*(-1 + xa + xb))),cone)
+      g174 = hp_glog((cone*(r1 + r2*r3*r6))/(r1 - xb*(-1 + xa + xb)),(cone*(-(r1*(1 + xa)) + r2*r3*r4*(-1 + xb) + xa*xb*(xa + xb)))/
+     &((1 + xa)*(-r1 + xb*(-1 + xa + xb))),cone)
+      g175 = hp_glog((cone*(r1 + r2*r3*r6))/(r1 - xb*(-1 + xa + xb)),(cone*(r1 - r1*xa - r2*r3*r4*(-1 + xb) + xa*xb*(-2 + xa + xb)))
+     &/((-1 + xa)*(-r1 + xb*(-1 + xa + xb))),cone)
+      g176 = hp_glog((cone*(r1 + r2*r3*r6))/(r1 - xb*(-1 + xa + xb)),(cone*(r1 - r1*xa + r2*r3*r4*(-1 + xb) + xa*xb*(-2 + xa + xb)))
+     &/((-1 + xa)*(-r1 + xb*(-1 + xa + xb))),cone)
       g177 = hp_glog((cone*(r2*r3*r6*(-1 + xb) + 2*xa*xb - r1*(1 + xb)))/((1 + xb)*(-r1 + xb*(-1 + xa + xb))),cone,cone)
-      g178 = hp_glog((cone*(r2*r3*r6*(-1 + xb) + 2*xa*xb - r1*(1 + xb)))/((1 + xb)*(-r1 + xb*(-1 + xa + xb))),(cone*(r1 - xa))/(r1 - xb*(-1 + xa + xb)),cone)
-      g179 = hp_glog((cone*(r2*r3*r6*(-1 + xb) + 2*xa*xb - r1*(1 + xb)))/((1 + xb)*(-r1 + xb*(-1 + xa + xb))),(cone*(r1 - xa*xb))/(r1 - xb*(-1 + xa + xb)),cone)
-      g180 = hp_glog((cone*(r2*r3*r6*(-1 + xb) + 2*xa*xb - r1*(1 + xb)))/((1 + xb)*(-r1 + xb*(-1 + xa + xb))),(cone*(-(r1*(1 + xa)) - r2*r3*r4*(-1 + xb) + xa*xb*(xa + xb)))/((1 + xa)*(-r1 + xb*(-1 + xa + xb))),cone)
-      g181 = hp_glog((cone*(r2*r3*r6*(-1 + xb) + 2*xa*xb - r1*(1 + xb)))/((1 + xb)*(-r1 + xb*(-1 + xa + xb))),(cone*(-(r1*(1 + xa)) + r2*r3*r4*(-1 + xb) + xa*xb*(xa + xb)))/((1 + xa)*(-r1 + xb*(-1 + xa + xb))),cone)
-      g182 = hp_glog((cone*(r2*r3*r6*(-1 + xb) + 2*xa*xb - r1*(1 + xb)))/((1 + xb)*(-r1 + xb*(-1 + xa + xb))),(cone*(r1 - r1*xa - r2*r3*r4*(-1 + xb) + xa*xb*(-2 + xa + xb)))/((-1 + xa)*(-r1 + xb*(-1 + xa + xb))),cone)
-      g183 = hp_glog((cone*(r2*r3*r6*(-1 + xb) + 2*xa*xb - r1*(1 + xb)))/((1 + xb)*(-r1 + xb*(-1 + xa + xb))),(cone*(r1 - r1*xa + r2*r3*r4*(-1 + xb) + xa*xb*(-2 + xa + xb)))/((-1 + xa)*(-r1 + xb*(-1 + xa + xb))),cone)
+      g178 = hp_glog((cone*(r2*r3*r6*(-1 + xb) + 2*xa*xb - r1*(1 + xb)))/((1 + xb)*(-r1 + xb*(-1 + xa + xb))),(cone*(r1 - xa))/(r1 -
+     & xb*(-1 + xa + xb)),cone)
+      g179 = hp_glog((cone*(r2*r3*r6*(-1 + xb) + 2*xa*xb - r1*(1 + xb)))/((1 + xb)*(-r1 + xb*(-1 + xa + xb))),(cone*(r1 - xa*xb))/(
+     &r1 - xb*(-1 + xa + xb)),cone)
+      g180 = hp_glog((cone*(r2*r3*r6*(-1 + xb) + 2*xa*xb - r1*(1 + xb)))/((1 + xb)*(-r1 + xb*(-1 + xa + xb))),(cone*(-(r1*(1 + xa)) 
+     &- r2*r3*r4*(-1 + xb) + xa*xb*(xa + xb)))/((1 + xa)*(-r1 + xb*(-1 + xa + xb))),cone)
+      g181 = hp_glog((cone*(r2*r3*r6*(-1 + xb) + 2*xa*xb - r1*(1 + xb)))/((1 + xb)*(-r1 + xb*(-1 + xa + xb))),(cone*(-(r1*(1 + xa)) 
+     &+ r2*r3*r4*(-1 + xb) + xa*xb*(xa + xb)))/((1 + xa)*(-r1 + xb*(-1 + xa + xb))),cone)
+      g182 = hp_glog((cone*(r2*r3*r6*(-1 + xb) + 2*xa*xb - r1*(1 + xb)))/((1 + xb)*(-r1 + xb*(-1 + xa + xb))),(cone*(r1 - r1*xa - 
+     &r2*r3*r4*(-1 + xb) + xa*xb*(-2 + xa + xb)))/((-1 + xa)*(-r1 + xb*(-1 + xa + xb))),cone)
+      g183 = hp_glog((cone*(r2*r3*r6*(-1 + xb) + 2*xa*xb - r1*(1 + xb)))/((1 + xb)*(-r1 + xb*(-1 + xa + xb))),(cone*(r1 - r1*xa + 
+     &r2*r3*r4*(-1 + xb) + xa*xb*(-2 + xa + xb)))/((-1 + xa)*(-r1 + xb*(-1 + xa + xb))),cone)
       g184 = hp_glog(-((cone*(r2*r3*r6*(-1 + xb) - 2*xa*xb + r1*(1 + xb)))/((1 + xb)*(-r1 + xb*(-1 + xa + xb)))),cone,cone)
-      g185 = hp_glog(-((cone*(r2*r3*r6*(-1 + xb) - 2*xa*xb + r1*(1 + xb)))/((1 + xb)*(-r1 + xb*(-1 + xa + xb)))),(cone*(r1 - xa))/(r1 - xb*(-1 + xa + xb)),cone)
-      g186 = hp_glog(-((cone*(r2*r3*r6*(-1 + xb) - 2*xa*xb + r1*(1 + xb)))/((1 + xb)*(-r1 + xb*(-1 + xa + xb)))),(cone*(r1 - xa*xb))/(r1 - xb*(-1 + xa + xb)),cone)
-      g187 = hp_glog(-((cone*(r2*r3*r6*(-1 + xb) - 2*xa*xb + r1*(1 + xb)))/((1 + xb)*(-r1 + xb*(-1 + xa + xb)))),(cone*(-(r1*(1 + xa)) - r2*r3*r4*(-1 + xb) + xa*xb*(xa + xb)))/((1 + xa)*(-r1 + xb*(-1 + xa + xb))),cone)
-      g188 = hp_glog(-((cone*(r2*r3*r6*(-1 + xb) - 2*xa*xb + r1*(1 + xb)))/((1 + xb)*(-r1 + xb*(-1 + xa + xb)))),(cone*(-(r1*(1 + xa)) + r2*r3*r4*(-1 + xb) + xa*xb*(xa + xb)))/((1 + xa)*(-r1 + xb*(-1 + xa + xb))),cone)
-      g189 = hp_glog(-((cone*(r2*r3*r6*(-1 + xb) - 2*xa*xb + r1*(1 + xb)))/((1 + xb)*(-r1 + xb*(-1 + xa + xb)))),(cone*(r1 - r1*xa - r2*r3*r4*(-1 + xb) + xa*xb*(-2 + xa + xb)))/((-1 + xa)*(-r1 + xb*(-1 + xa + xb))),cone)
-      g190 = hp_glog(-((cone*(r2*r3*r6*(-1 + xb) - 2*xa*xb + r1*(1 + xb)))/((1 + xb)*(-r1 + xb*(-1 + xa + xb)))),(cone*(r1 - r1*xa + r2*r3*r4*(-1 + xb) + xa*xb*(-2 + xa + xb)))/((-1 + xa)*(-r1 + xb*(-1 + xa + xb))),cone)
-      g191 = hp_glog((cone*(-xa + xb - r1*(-2 + xa + xb) + (-1 + xa)*xb*(xa + xb)))/((-2 + xa + xb)*(-r1 + xb*(-1 + xa + xb))),cone,cone)
+      g185 = hp_glog(-((cone*(r2*r3*r6*(-1 + xb) - 2*xa*xb + r1*(1 + xb)))/((1 + xb)*(-r1 + xb*(-1 + xa + xb)))),(cone*(r1 - xa))/(
+     &r1 - xb*(-1 + xa + xb)),cone)
+      g186 = hp_glog(-((cone*(r2*r3*r6*(-1 + xb) - 2*xa*xb + r1*(1 + xb)))/((1 + xb)*(-r1 + xb*(-1 + xa + xb)))),(cone*(r1 - xa*xb))
+     &/(r1 - xb*(-1 + xa + xb)),cone)
+      g187 = hp_glog(-((cone*(r2*r3*r6*(-1 + xb) - 2*xa*xb + r1*(1 + xb)))/((1 + xb)*(-r1 + xb*(-1 + xa + xb)))),(cone*(-(r1*(1 + 
+     &xa)) - r2*r3*r4*(-1 + xb) + xa*xb*(xa + xb)))/((1 + xa)*(-r1 + xb*(-1 + xa + xb))),cone)
+      g188 = hp_glog(-((cone*(r2*r3*r6*(-1 + xb) - 2*xa*xb + r1*(1 + xb)))/((1 + xb)*(-r1 + xb*(-1 + xa + xb)))),(cone*(-(r1*(1 + 
+     &xa)) + r2*r3*r4*(-1 + xb) + xa*xb*(xa + xb)))/((1 + xa)*(-r1 + xb*(-1 + xa + xb))),cone)
+      g189 = hp_glog(-((cone*(r2*r3*r6*(-1 + xb) - 2*xa*xb + r1*(1 + xb)))/((1 + xb)*(-r1 + xb*(-1 + xa + xb)))),(cone*(r1 - r1*xa -
+     & r2*r3*r4*(-1 + xb) + xa*xb*(-2 + xa + xb)))/((-1 + xa)*(-r1 + xb*(-1 + xa + xb))),cone)
+      g190 = hp_glog(-((cone*(r2*r3*r6*(-1 + xb) - 2*xa*xb + r1*(1 + xb)))/((1 + xb)*(-r1 + xb*(-1 + xa + xb)))),(cone*(r1 - r1*xa +
+     & r2*r3*r4*(-1 + xb) + xa*xb*(-2 + xa + xb)))/((-1 + xa)*(-r1 + xb*(-1 + xa + xb))),cone)
+      g191 = hp_glog((cone*(-xa + xb - r1*(-2 + xa + xb) + (-1 + xa)*xb*(xa + xb)))/((-2 + xa + xb)*(-r1 + xb*(-1 + xa + xb))),cone,
+     &cone)
       g192 = hp_glog((-2*cone*(r1*(-1 + xa + xb) + xa*(-1 + xb*(xa + xb))))/((-1 + xb)**2*(xa + xb)),cone,cone)
-      g193 = hp_glog((-2*cone*(r1*(-1 + xa + xb) + xa*(-1 + xb*(xa + xb))))/((-1 + xb)**2*(xa + xb)),-((cone*(r1 + xa))/((-1 + xb)*(xa + xb))),cone)
-      g194 = hp_glog((-2*cone*(r1*(-1 + xa + xb) + xa*(-1 + xb*(xa + xb))))/((-1 + xb)**2*(xa + xb)),(cone*(r1 + xa*xb))/(xb - xb**2),cone)
-      g195 = hp_glog((-2*cone*(r1*(-1 + xa + xb) + xa*(-1 + xb*(xa + xb))))/((-1 + xb)**2*(xa + xb)),-((cone*(r1*(r5 + xb) + xb*(xa + r5*(-1 + xa + xb) - xa*(-1 + xb)*(xa + xb))))/((1 + xa)*(-1 + xb)*xb*(xa + xb))),cone)
-      g196 = hp_glog((-2*cone*(r1*(-1 + xa + xb) + xa*(-1 + xb*(xa + xb))))/((-1 + xb)**2*(xa + xb)),(cone*(r1*(r5 + xb) + xb*(xa + r5*(-1 + xa + xb) + xa*(-1 + xb)*(xa + xb))))/((-1 + xa)*(-1 + xb)*xb*(xa + xb)),cone)
-      g197 = hp_glog((-2*cone*(r1*(-1 + xa + xb) + xa*(-1 + xb*(xa + xb))))/((-1 + xb)**2*(xa + xb)),(cone*(r1*(r5 - xb) + xb*(-xa + r5*(-1 + xa + xb) + xa*(-1 + xb)*(xa + xb))))/((1 + xa)*(-1 + xb)*xb*(xa + xb)),cone)
-      g198 = hp_glog((-2*cone*(r1*(-1 + xa + xb) + xa*(-1 + xb*(xa + xb))))/((-1 + xb)**2*(xa + xb)),(cone*(r1*(-r5 + xb) + xb*(xa - r5*(-1 + xa + xb) + xa*(-1 + xb)*(xa + xb))))/((-1 + xa)*(-1 + xb)*xb*(xa + xb)),cone)
+      g193 = hp_glog((-2*cone*(r1*(-1 + xa + xb) + xa*(-1 + xb*(xa + xb))))/((-1 + xb)**2*(xa + xb)),-((cone*(r1 + xa))/((-1 + xb)*(
+     &xa + xb))),cone)
+      g194 = hp_glog((-2*cone*(r1*(-1 + xa + xb) + xa*(-1 + xb*(xa + xb))))/((-1 + xb)**2*(xa + xb)),(cone*(r1 + xa*xb))/(xb - 
+     &xb**2),cone)
+      g195 = hp_glog((-2*cone*(r1*(-1 + xa + xb) + xa*(-1 + xb*(xa + xb))))/((-1 + xb)**2*(xa + xb)),-((cone*(r1*(r5 + xb) + xb*(xa 
+     &+ r5*(-1 + xa + xb) - xa*(-1 + xb)*(xa + xb))))/((1 + xa)*(-1 + xb)*xb*(xa + xb))),cone)
+      g196 = hp_glog((-2*cone*(r1*(-1 + xa + xb) + xa*(-1 + xb*(xa + xb))))/((-1 + xb)**2*(xa + xb)),(cone*(r1*(r5 + xb) + xb*(xa + 
+     &r5*(-1 + xa + xb) + xa*(-1 + xb)*(xa + xb))))/((-1 + xa)*(-1 + xb)*xb*(xa + xb)),cone)
+      g197 = hp_glog((-2*cone*(r1*(-1 + xa + xb) + xa*(-1 + xb*(xa + xb))))/((-1 + xb)**2*(xa + xb)),(cone*(r1*(r5 - xb) + xb*(-xa +
+     & r5*(-1 + xa + xb) + xa*(-1 + xb)*(xa + xb))))/((1 + xa)*(-1 + xb)*xb*(xa + xb)),cone)
+      g198 = hp_glog((-2*cone*(r1*(-1 + xa + xb) + xa*(-1 + xb*(xa + xb))))/((-1 + xb)**2*(xa + xb)),(cone*(r1*(-r5 + xb) + xb*(xa -
+     & r5*(-1 + xa + xb) + xa*(-1 + xb)*(xa + xb))))/((-1 + xa)*(-1 + xb)*xb*(xa + xb)),cone)
       g199 = hp_glog(-((cone*(-xa + xb + r1*(-2 + xa + xb) + (-1 + xa)*xb*(xa + xb)))/((-1 + xb)**2*(xa + xb))),cone,cone)
       g200 = hp_glog((cone*(-r7 - r8*r9 + r2*r3*(xa + xb)))/2.0_ki,(cone*(-r10 + r2))/r3,(cone*r11)/r19)
       g201 = hp_glog((cone*(-r7 - r8*r9 + r2*r3*(xa + xb)))/2.0_ki,(cone*(-r10 + r2))/r3,(cone*r12)/r20)

--- a/src/hp_Intcts/include/hp_a12casbrcas_functions.h
+++ b/src/hp_Intcts/include/hp_a12casbrcas_functions.h
@@ -731,15 +731,19 @@
       l53 = hp_mylog(cone*(r6 + xa*xb))
       l54 = hp_mylog(cone*(r6 - im*r2*r3*(-1 + xb) + xa*xb))
       l55 = hp_mylog(cone*(r6 + im*r2*r3*(-1 + xb) + xa*xb))
-      l56 = hp_mylog(cone*(xa - xb + 2*r1*r2*r3*(-1 + xa)*(-1 + xb*(-1 + xa + xb)) + xb*(2*xa**3*xb + xb**2 + xa*(4 + (-4 + xb)*xb**2) + xa**2*(-3 + xb*(-4 + 3*xb)))))
-      l57 = hp_mylog(cone*(xa - xb - 2*r1*r2*r3*(-1 + xa)*(-1 + xb*(-1 + xa + xb)) + xb*(2*xa**3*xb + xb**2 + xa*(4 + (-4 + xb)*xb**2) + xa**2*(-3 + xb*(-4 + 3*xb)))))
+      l56 = hp_mylog(cone*(xa - xb + 2*r1*r2*r3*(-1 + xa)*(-1 + xb*(-1 + xa + xb)) + xb*(2*xa**3*xb + xb**2 + xa*(4 + (-4 + xb)
+     &*xb**2) + xa**2*(-3 + xb*(-4 + 3*xb)))))
+      l57 = hp_mylog(cone*(xa - xb - 2*r1*r2*r3*(-1 + xa)*(-1 + xb*(-1 + xa + xb)) + xb*(2*xa**3*xb + xb**2 + xa*(4 + (-4 + xb)
+     &*xb**2) + xa**2*(-3 + xb*(-4 + 3*xb)))))
       l58 = hp_mylog(cone*(r5*(-1 + xb) + xb - xa*xb*(-1 + xa + xb)))
       l59 = hp_mylog(cone*(r5 + xb - r5*xb - xa*xb*(-1 + xa + xb)))
       l60 = hp_mylog((cone*(-(r1*r2) + r3*xa))/(-(r1*r2) + r3))
       l61 = hp_mylog((cone*(r1*r2 + r3*xa))/(r1*r2 + r3))
       l62 = hp_mylog(2*cone*(xa + r6*(-1 + xa + xb) - xa*xb*(xa + xb)))
       l63 = hp_mylog(cone*(r6*(-1 + xa) + xa - xa*xb*(-1 + xa + xb)))
-      l64 = hp_mylog((cone*(-1 + r2)*(1 + r2)*(-1 + r3)*(1 + r3)*(r6 - xa)*xb*(r6*(1 + xa) + r2*r3*r4*(-1 + xb) - xa*xb*(xa + xb))*(-(r6*(1 + xa)) + r2*r3*r4*(-1 + xb) + xa*xb*(xa + xb)))/((1 + xa)*(-r6 + xa*xb)*(r6 - r6*xa - r2*r3*r4*(-1 + xb) + xa*xb*(-2 + xa + xb))*(r6 - r6*xa + r2*r3*r4*(-1 + xb) + xa*xb*(-2 + xa + xb))*(-r6 + xb*(-1 + xa + xb))))
+      l64 = hp_mylog((cone*(-1 + r2)*(1 + r2)*(-1 + r3)*(1 + r3)*(r6 - xa)*xb*(r6*(1 + xa) + r2*r3*r4*(-1 + xb) - xa*xb*(xa + xb))*(
+     &-(r6*(1 + xa)) + r2*r3*r4*(-1 + xb) + xa*xb*(xa + xb)))/((1 + xa)*(-r6 + xa*xb)*(r6 - r6*xa - r2*r3*r4*(-1 + xb) + 
+     &xa*xb*(-2 + xa + xb))*(r6 - r6*xa + r2*r3*r4*(-1 + xb) + xa*xb*(-2 + xa + xb))*(-r6 + xb*(-1 + xa + xb))))
       l65 = hp_mylog((cone*(-1 + xb)*(xa + xb))/(r6 - xa))
       l66 = hp_mylog((cone*(-1 + xb)*xb)/(r6 - xa*xb))
       l67 = hp_mylog((cone*r3*(r2 + im*r3)*(-1 + xb))/(r2*r3*(-1 + xb) + im*(r6 - xa*xb)))
@@ -754,7 +758,8 @@
       l76 = hp_mylog(cone*(r5*(r6 - xb)*(-1 + xb) + xb*(r6 - r6*xa*(-1 + xa + xb) + xa*(1 + xa - xa*xb*(xa + xb)))))
       l77 = hp_mylog(cone*(-(r5*(-1 + xb)*(r6 + xb)) - xb*(r6*(-1 + xa*(-1 + xa + xb)) + xa*(1 - 2*xb + xa*(-1 + xb*(xa + xb))))))
       l78 = hp_mylog(cone*(r5*(-1 + xb)*(r6 + xb) - xb*(r6*(-1 + xa*(-1 + xa + xb)) + xa*(1 - 2*xb + xa*(-1 + xb*(xa + xb))))))
-      l79 = hp_mylog(-((cone*(-r7 - r8*r9 + r2*r3*xa + r2*r3*xb - (2*r11)/Sqrt((r2 + 1/Sqrt(xa + xb))/r2)))/(r7 + r8*r9 - r2*r3*(xa + xb))))
+      l79 = hp_mylog(-((cone*(-r7 - r8*r9 + r2*r3*xa + r2*r3*xb - (2*r11)/Sqrt((r2 + 1/Sqrt(xa + xb))/r2)))/(r7 + r8*r9 - r2*r3*(xa 
+     &+ xb))))
       l80 = hp_mylog((cone*(r10 - r2))/r3)
       l81 = hp_mylog((cone*(r10 + r2))/r3)
       l82 = hp_mylog(cone*r13)
@@ -764,20 +769,34 @@
       l86 = hp_mylog(cone*(-r1 + r10*r3))
       l87 = hp_mylog(cone*(r1 + r10*r3))
       l88 = hp_mylog((cone*(r7 + r8*r9 - r2*r3*xa - r2*r3*xb + (2*r12)/Sqrt(1 + r2/Sqrt(xa + xb))))/(r7 + r8*r9 - r2*r3*(xa + xb)))
-      l89 = hp_mylog((cone*(-r7 + r8*r9 + r2*r3*xa + r2*r3*xb + (2*r11)/Sqrt((r2 + 1/Sqrt(xa + xb))/r2)))/(-r7 + r8*r9 + r2*r3*(xa + xb)))
-      l90 = hp_mylog((cone*(-r7 + r8*r9 + r2*r3*xa + r2*r3*xb + (2*r12)/Sqrt(1 + r2/Sqrt(xa + xb))))/(-r7 + r8*r9 + r2*r3*(xa + xb)))
-      l91 = hp_mylog((cone*(-r7 + r8*r9 + r2*r3*xa + r2*r3*xb - (2*r11)/Sqrt((r2 + 1/Sqrt(xa + xb))/r2)))/(-r7 + r8*r9 + r2*r3*(xa + xb)))
-      l92 = hp_mylog((cone*(-r7 + r8*r9 + r2*r3*xa + r2*r3*xb - (2*r12)/Sqrt(1 + r2/Sqrt(xa + xb))))/(-r7 + r8*r9 + r2*r3*(xa + xb)))
-      l93 = hp_mylog(-((cone*(-r7 - r8*r9 + r2*r3*xa + r2*r3*xb + (2*r11)/Sqrt((r2 + 1/Sqrt(xa + xb))/r2)))/(r7 + r8*r9 - r2*r3*(xa + xb))))
-      l94 = hp_mylog(-((cone*(-r7 - r8*r9 + r2*r3*xa + r2*r3*xb + (2*r12)/Sqrt(1 + r2/Sqrt(xa + xb))))/(r7 + r8*r9 - r2*r3*(xa + xb))))
-      l95 = hp_mylog((cone*(r7 + r15*r8 + r2*r3*xa + r2*r3*xb + (2*r11)/Sqrt((r2 + 1/Sqrt(xa + xb))/r2)))/(r7 + r15*r8 + r2*r3*(xa + xb)))
-      l96 = hp_mylog((cone*(r7 + r15*r8 + r2*r3*xa + r2*r3*xb + (2*r12)/Sqrt(1 + r2/Sqrt(xa + xb))))/(r7 + r15*r8 + r2*r3*(xa + xb)))
-      l97 = hp_mylog((cone*(r7 - r15*r8 + r2*r3*xa + r2*r3*xb - (2*r11)/Sqrt((r2 + 1/Sqrt(xa + xb))/r2)))/(r7 - r15*r8 + r2*r3*(xa + xb)))
-      l98 = hp_mylog((cone*(r7 - r15*r8 + r2*r3*xa + r2*r3*xb - (2*r12)/Sqrt(1 + r2/Sqrt(xa + xb))))/(r7 - r15*r8 + r2*r3*(xa + xb)))
-      l99 = hp_mylog((cone*(r7 - r15*r8 + r2*r3*xa + r2*r3*xb + (2*r11)/Sqrt((r2 + 1/Sqrt(xa + xb))/r2)))/(r7 - r15*r8 + r2*r3*(xa + xb)))
-      l100 = hp_mylog((cone*(r7 - r15*r8 + r2*r3*xa + r2*r3*xb + (2*r12)/Sqrt(1 + r2/Sqrt(xa + xb))))/(r7 - r15*r8 + r2*r3*(xa + xb)))
-      l101 = hp_mylog((cone*(r7 + r15*r8 + r2*r3*xa + r2*r3*xb - (2*r11)/Sqrt((r2 + 1/Sqrt(xa + xb))/r2)))/(r7 + r15*r8 + r2*r3*(xa + xb)))
-      l102 = hp_mylog((cone*(r7 + r15*r8 + r2*r3*xa + r2*r3*xb - (2*r12)/Sqrt(1 + r2/Sqrt(xa + xb))))/(r7 + r15*r8 + r2*r3*(xa + xb)))
+      l89 = hp_mylog((cone*(-r7 + r8*r9 + r2*r3*xa + r2*r3*xb + (2*r11)/Sqrt((r2 + 1/Sqrt(xa + xb))/r2)))/(-r7 + r8*r9 + r2*r3*(xa +
+     & xb)))
+      l90 = hp_mylog((cone*(-r7 + r8*r9 + r2*r3*xa + r2*r3*xb + (2*r12)/Sqrt(1 + r2/Sqrt(xa + xb))))/(-r7 + r8*r9 + r2*r3*(xa + xb))
+     &)
+      l91 = hp_mylog((cone*(-r7 + r8*r9 + r2*r3*xa + r2*r3*xb - (2*r11)/Sqrt((r2 + 1/Sqrt(xa + xb))/r2)))/(-r7 + r8*r9 + r2*r3*(xa +
+     & xb)))
+      l92 = hp_mylog((cone*(-r7 + r8*r9 + r2*r3*xa + r2*r3*xb - (2*r12)/Sqrt(1 + r2/Sqrt(xa + xb))))/(-r7 + r8*r9 + r2*r3*(xa + xb))
+     &)
+      l93 = hp_mylog(-((cone*(-r7 - r8*r9 + r2*r3*xa + r2*r3*xb + (2*r11)/Sqrt((r2 + 1/Sqrt(xa + xb))/r2)))/(r7 + r8*r9 - r2*r3*(xa 
+     &+ xb))))
+      l94 = hp_mylog(-((cone*(-r7 - r8*r9 + r2*r3*xa + r2*r3*xb + (2*r12)/Sqrt(1 + r2/Sqrt(xa + xb))))/(r7 + r8*r9 - r2*r3*(xa + xb)
+     &)))
+      l95 = hp_mylog((cone*(r7 + r15*r8 + r2*r3*xa + r2*r3*xb + (2*r11)/Sqrt((r2 + 1/Sqrt(xa + xb))/r2)))/(r7 + r15*r8 + r2*r3*(xa +
+     & xb)))
+      l96 = hp_mylog((cone*(r7 + r15*r8 + r2*r3*xa + r2*r3*xb + (2*r12)/Sqrt(1 + r2/Sqrt(xa + xb))))/(r7 + r15*r8 + r2*r3*(xa + xb))
+     &)
+      l97 = hp_mylog((cone*(r7 - r15*r8 + r2*r3*xa + r2*r3*xb - (2*r11)/Sqrt((r2 + 1/Sqrt(xa + xb))/r2)))/(r7 - r15*r8 + r2*r3*(xa +
+     & xb)))
+      l98 = hp_mylog((cone*(r7 - r15*r8 + r2*r3*xa + r2*r3*xb - (2*r12)/Sqrt(1 + r2/Sqrt(xa + xb))))/(r7 - r15*r8 + r2*r3*(xa + xb))
+     &)
+      l99 = hp_mylog((cone*(r7 - r15*r8 + r2*r3*xa + r2*r3*xb + (2*r11)/Sqrt((r2 + 1/Sqrt(xa + xb))/r2)))/(r7 - r15*r8 + r2*r3*(xa +
+     & xb)))
+      l100 = hp_mylog((cone*(r7 - r15*r8 + r2*r3*xa + r2*r3*xb + (2*r12)/Sqrt(1 + r2/Sqrt(xa + xb))))/(r7 - r15*r8 + r2*r3*(xa + xb)
+     &))
+      l101 = hp_mylog((cone*(r7 + r15*r8 + r2*r3*xa + r2*r3*xb - (2*r11)/Sqrt((r2 + 1/Sqrt(xa + xb))/r2)))/(r7 + r15*r8 + r2*r3*(xa 
+     &+ xb)))
+      l102 = hp_mylog((cone*(r7 + r15*r8 + r2*r3*xa + r2*r3*xb - (2*r12)/Sqrt(1 + r2/Sqrt(xa + xb))))/(r7 + r15*r8 + r2*r3*(xa + xb)
+     &))
       l103 = hp_mylog((cone*(r1*r2 - r3)*(r1 + r2*r3))/((r1*r2 + r3)*(r1 - r2*r3)))
       d1 = hp_cli2((cone*(1 - xb))/2.0_ki)
       d2 = hp_cli2(cone*(1 - xb))
@@ -858,10 +877,14 @@
       g56 = hp_glog(czip,(cone*(r5 + xa))/(xa - xa*xb),cone)
       g57 = hp_glog(czip,-((cone*(r6 + xa))/((-1 + xb)*(xa + xb))),cone)
       g58 = hp_glog(czip,(cone*(r6 + xa*xb))/(xb - xb**2),cone)
-      g59 = hp_glog(czip,(cone*(-(r6*xb) + xa*xb*(-1 + xa*(-1 + xb) + (-1 + xb)*xb) - r5*(r6 + xb*(-1 + xa + xb))))/((1 + xa)*(-1 + xb)*xb*(xa + xb)),cone)
-      g60 = hp_glog(czip,(cone*(r5*(r6 + xb*(-1 + xa + xb)) + xb*(r6 + xa*(1 + xa*(-1 + xb) + (-1 + xb)*xb))))/((-1 + xa)*(-1 + xb)*xb*(xa + xb)),cone)
-      g61 = hp_glog(czip,(cone*(-(r6*xb) + xa*xb*(-1 + xa*(-1 + xb) + (-1 + xb)*xb) + r5*(r6 + xb*(-1 + xa + xb))))/((1 + xa)*(-1 + xb)*xb*(xa + xb)),cone)
-      g62 = hp_glog(czip,(cone*(-(r5*(r6 + xb*(-1 + xa + xb))) + xb*(r6 + xa*(1 + xa*(-1 + xb) + (-1 + xb)*xb))))/((-1 + xa)*(-1 + xb)*xb*(xa + xb)),cone)
+      g59 = hp_glog(czip,(cone*(-(r6*xb) + xa*xb*(-1 + xa*(-1 + xb) + (-1 + xb)*xb) - r5*(r6 + xb*(-1 + xa + xb))))/((1 + xa)*(-1 + 
+     &xb)*xb*(xa + xb)),cone)
+      g60 = hp_glog(czip,(cone*(r5*(r6 + xb*(-1 + xa + xb)) + xb*(r6 + xa*(1 + xa*(-1 + xb) + (-1 + xb)*xb))))/((-1 + xa)*(-1 + xb)
+     &*xb*(xa + xb)),cone)
+      g61 = hp_glog(czip,(cone*(-(r6*xb) + xa*xb*(-1 + xa*(-1 + xb) + (-1 + xb)*xb) + r5*(r6 + xb*(-1 + xa + xb))))/((1 + xa)*(-1 + 
+     &xb)*xb*(xa + xb)),cone)
+      g62 = hp_glog(czip,(cone*(-(r5*(r6 + xb*(-1 + xa + xb))) + xb*(r6 + xa*(1 + xa*(-1 + xb) + (-1 + xb)*xb))))/((-1 + xa)*(-1 + 
+     &xb)*xb*(xa + xb)),cone)
       g63 = hp_glog(cone,-cone,cone*xa)
       g64 = hp_glog(cone,-cone,cone*xb)
       g65 = hp_glog(cone,czip,cone*xa)
@@ -1024,31 +1047,51 @@
       g222 = hp_glog(-((cone*(r6 + xa))/((-1 + xb)*(xa + xb))),cone,cone)
       g223 = hp_glog(-((cone*(r6 + xa))/((-1 + xb)*(xa + xb))),-((cone*(r6 + xa))/((-1 + xb)*(xa + xb))),cone)
       g224 = hp_glog(-((cone*(r6 + xa))/((-1 + xb)*(xa + xb))),(cone*(r6 + xa*xb))/(xb - xb**2),cone)
-      g225 = hp_glog(-((cone*(r6 + xa))/((-1 + xb)*(xa + xb))),(cone*(-(r6*xb) + xa*xb*(-1 + xa*(-1 + xb) + (-1 + xb)*xb) - r5*(r6 + xb*(-1 + xa + xb))))/((1 + xa)*(-1 + xb)*xb*(xa + xb)),cone)
-      g226 = hp_glog(-((cone*(r6 + xa))/((-1 + xb)*(xa + xb))),(cone*(r5*(r6 + xb*(-1 + xa + xb)) + xb*(r6 + xa*(1 + xa*(-1 + xb) + (-1 + xb)*xb))))/((-1 + xa)*(-1 + xb)*xb*(xa + xb)),cone)
-      g227 = hp_glog(-((cone*(r6 + xa))/((-1 + xb)*(xa + xb))),(cone*(-(r6*xb) + xa*xb*(-1 + xa*(-1 + xb) + (-1 + xb)*xb) + r5*(r6 + xb*(-1 + xa + xb))))/((1 + xa)*(-1 + xb)*xb*(xa + xb)),cone)
-      g228 = hp_glog(-((cone*(r6 + xa))/((-1 + xb)*(xa + xb))),(cone*(-(r5*(r6 + xb*(-1 + xa + xb))) + xb*(r6 + xa*(1 + xa*(-1 + xb) + (-1 + xb)*xb))))/((-1 + xa)*(-1 + xb)*xb*(xa + xb)),cone)
+      g225 = hp_glog(-((cone*(r6 + xa))/((-1 + xb)*(xa + xb))),(cone*(-(r6*xb) + xa*xb*(-1 + xa*(-1 + xb) + (-1 + xb)*xb) - r5*(r6 +
+     & xb*(-1 + xa + xb))))/((1 + xa)*(-1 + xb)*xb*(xa + xb)),cone)
+      g226 = hp_glog(-((cone*(r6 + xa))/((-1 + xb)*(xa + xb))),(cone*(r5*(r6 + xb*(-1 + xa + xb)) + xb*(r6 + xa*(1 + xa*(-1 + xb) + 
+     &(-1 + xb)*xb))))/((-1 + xa)*(-1 + xb)*xb*(xa + xb)),cone)
+      g227 = hp_glog(-((cone*(r6 + xa))/((-1 + xb)*(xa + xb))),(cone*(-(r6*xb) + xa*xb*(-1 + xa*(-1 + xb) + (-1 + xb)*xb) + r5*(r6 +
+     & xb*(-1 + xa + xb))))/((1 + xa)*(-1 + xb)*xb*(xa + xb)),cone)
+      g228 = hp_glog(-((cone*(r6 + xa))/((-1 + xb)*(xa + xb))),(cone*(-(r5*(r6 + xb*(-1 + xa + xb))) + xb*(r6 + xa*(1 + xa*(-1 + xb)
+     & + (-1 + xb)*xb))))/((-1 + xa)*(-1 + xb)*xb*(xa + xb)),cone)
       g229 = hp_glog((cone*(r2*r3*(-1 + xb) - (czip,1)*(r6 + xa*xb)))/((r2 + (czip,1)*r3)*r3*(-1 + xb)),cone,cone)
-      g230 = hp_glog((cone*(r2*r3*(-1 + xb) - (czip,1)*(r6 + xa*xb)))/((r2 + (czip,1)*r3)*r3*(-1 + xb)),-((cone*(r6 + xa))/((-1 + xb)*(xa + xb))),cone)
-      g231 = hp_glog((cone*(r2*r3*(-1 + xb) - (czip,1)*(r6 + xa*xb)))/((r2 + (czip,1)*r3)*r3*(-1 + xb)),(cone*(r6 + xa*xb))/(xb - xb**2),cone)
-      g232 = hp_glog((cone*(r2*r3*(-1 + xb) - (czip,1)*(r6 + xa*xb)))/((r2 + (czip,1)*r3)*r3*(-1 + xb)),(cone*(-(r6*xb) + xa*xb*(-1 + xa*(-1 + xb) + (-1 + xb)*xb) - r5*(r6 + xb*(-1 + xa + xb))))/((1 + xa)*(-1 + xb)*xb*(xa + xb)),cone)
-      g233 = hp_glog((cone*(r2*r3*(-1 + xb) - (czip,1)*(r6 + xa*xb)))/((r2 + (czip,1)*r3)*r3*(-1 + xb)),(cone*(r5*(r6 + xb*(-1 + xa + xb)) + xb*(r6 + xa*(1 + xa*(-1 + xb) + (-1 + xb)*xb))))/((-1 + xa)*(-1 + xb)*xb*(xa + xb)),cone)
-      g234 = hp_glog((cone*(r2*r3*(-1 + xb) - (czip,1)*(r6 + xa*xb)))/((r2 + (czip,1)*r3)*r3*(-1 + xb)),(cone*(-(r6*xb) + xa*xb*(-1 + xa*(-1 + xb) + (-1 + xb)*xb) + r5*(r6 + xb*(-1 + xa + xb))))/((1 + xa)*(-1 + xb)*xb*(xa + xb)),cone)
-      g235 = hp_glog((cone*(r2*r3*(-1 + xb) - (czip,1)*(r6 + xa*xb)))/((r2 + (czip,1)*r3)*r3*(-1 + xb)),(cone*(-(r5*(r6 + xb*(-1 + xa + xb))) + xb*(r6 + xa*(1 + xa*(-1 + xb) + (-1 + xb)*xb))))/((-1 + xa)*(-1 + xb)*xb*(xa + xb)),cone)
+      g230 = hp_glog((cone*(r2*r3*(-1 + xb) - (czip,1)*(r6 + xa*xb)))/((r2 + (czip,1)*r3)*r3*(-1 + xb)),-((cone*(r6 + xa))/((-1 + 
+     &xb)*(xa + xb))),cone)
+      g231 = hp_glog((cone*(r2*r3*(-1 + xb) - (czip,1)*(r6 + xa*xb)))/((r2 + (czip,1)*r3)*r3*(-1 + xb)),(cone*(r6 + xa*xb))/(xb - 
+     &xb**2),cone)
+      g232 = hp_glog((cone*(r2*r3*(-1 + xb) - (czip,1)*(r6 + xa*xb)))/((r2 + (czip,1)*r3)*r3*(-1 + xb)),(cone*(-(r6*xb) + xa*xb*(-1 
+     &+ xa*(-1 + xb) + (-1 + xb)*xb) - r5*(r6 + xb*(-1 + xa + xb))))/((1 + xa)*(-1 + xb)*xb*(xa + xb)),cone)
+      g233 = hp_glog((cone*(r2*r3*(-1 + xb) - (czip,1)*(r6 + xa*xb)))/((r2 + (czip,1)*r3)*r3*(-1 + xb)),(cone*(r5*(r6 + xb*(-1 + xa 
+     &+ xb)) + xb*(r6 + xa*(1 + xa*(-1 + xb) + (-1 + xb)*xb))))/((-1 + xa)*(-1 + xb)*xb*(xa + xb)),cone)
+      g234 = hp_glog((cone*(r2*r3*(-1 + xb) - (czip,1)*(r6 + xa*xb)))/((r2 + (czip,1)*r3)*r3*(-1 + xb)),(cone*(-(r6*xb) + xa*xb*(-1 
+     &+ xa*(-1 + xb) + (-1 + xb)*xb) + r5*(r6 + xb*(-1 + xa + xb))))/((1 + xa)*(-1 + xb)*xb*(xa + xb)),cone)
+      g235 = hp_glog((cone*(r2*r3*(-1 + xb) - (czip,1)*(r6 + xa*xb)))/((r2 + (czip,1)*r3)*r3*(-1 + xb)),(cone*(-(r5*(r6 + xb*(-1 + 
+     &xa + xb))) + xb*(r6 + xa*(1 + xa*(-1 + xb) + (-1 + xb)*xb))))/((-1 + xa)*(-1 + xb)*xb*(xa + xb)),cone)
       g236 = hp_glog((cone*(r2*r3*(-1 + xb) + (czip,1)*(r6 + xa*xb)))/((r2 - (czip,1)*r3)*r3*(-1 + r3**2)),cone,cone)
-      g237 = hp_glog((cone*(r2*r3*(-1 + xb) + (czip,1)*(r6 + xa*xb)))/((r2 - (czip,1)*r3)*r3*(-1 + r3**2)),-((cone*(r6 + xa))/((-1 + xb)*(xa + xb))),cone)
-      g238 = hp_glog((cone*(r2*r3*(-1 + xb) + (czip,1)*(r6 + xa*xb)))/((r2 - (czip,1)*r3)*r3*(-1 + r3**2)),(cone*(r6 + xa*xb))/(xb - xb**2),cone)
-      g239 = hp_glog((cone*(r2*r3*(-1 + xb) + (czip,1)*(r6 + xa*xb)))/((r2 - (czip,1)*r3)*r3*(-1 + r3**2)),(cone*(-(r6*xb) + xa*xb*(-1 + xa*(-1 + xb) + (-1 + xb)*xb) - r5*(r6 + xb*(-1 + xa + xb))))/((1 + xa)*(-1 + xb)*xb*(xa + xb)),cone)
-      g240 = hp_glog((cone*(r2*r3*(-1 + xb) + (czip,1)*(r6 + xa*xb)))/((r2 - (czip,1)*r3)*r3*(-1 + r3**2)),(cone*(r5*(r6 + xb*(-1 + xa + xb)) + xb*(r6 + xa*(1 + xa*(-1 + xb) + (-1 + xb)*xb))))/((-1 + xa)*(-1 + xb)*xb*(xa + xb)),cone)
-      g241 = hp_glog((cone*(r2*r3*(-1 + xb) + (czip,1)*(r6 + xa*xb)))/((r2 - (czip,1)*r3)*r3*(-1 + r3**2)),(cone*(-(r6*xb) + xa*xb*(-1 + xa*(-1 + xb) + (-1 + xb)*xb) + r5*(r6 + xb*(-1 + xa + xb))))/((1 + xa)*(-1 + xb)*xb*(xa + xb)),cone)
-      g242 = hp_glog((cone*(r2*r3*(-1 + xb) + (czip,1)*(r6 + xa*xb)))/((r2 - (czip,1)*r3)*r3*(-1 + r3**2)),(cone*(-(r5*(r6 + xb*(-1 + xa + xb))) + xb*(r6 + xa*(1 + xa*(-1 + xb) + (-1 + xb)*xb))))/((-1 + xa)*(-1 + xb)*xb*(xa + xb)),cone)
+      g237 = hp_glog((cone*(r2*r3*(-1 + xb) + (czip,1)*(r6 + xa*xb)))/((r2 - (czip,1)*r3)*r3*(-1 + r3**2)),-((cone*(r6 + xa))/((-1 +
+     & xb)*(xa + xb))),cone)
+      g238 = hp_glog((cone*(r2*r3*(-1 + xb) + (czip,1)*(r6 + xa*xb)))/((r2 - (czip,1)*r3)*r3*(-1 + r3**2)),(cone*(r6 + xa*xb))/(xb -
+     & xb**2),cone)
+      g239 = hp_glog((cone*(r2*r3*(-1 + xb) + (czip,1)*(r6 + xa*xb)))/((r2 - (czip,1)*r3)*r3*(-1 + r3**2)),(cone*(-(r6*xb) + xa*xb*(
+     &-1 + xa*(-1 + xb) + (-1 + xb)*xb) - r5*(r6 + xb*(-1 + xa + xb))))/((1 + xa)*(-1 + xb)*xb*(xa + xb)),cone)
+      g240 = hp_glog((cone*(r2*r3*(-1 + xb) + (czip,1)*(r6 + xa*xb)))/((r2 - (czip,1)*r3)*r3*(-1 + r3**2)),(cone*(r5*(r6 + xb*(-1 + 
+     &xa + xb)) + xb*(r6 + xa*(1 + xa*(-1 + xb) + (-1 + xb)*xb))))/((-1 + xa)*(-1 + xb)*xb*(xa + xb)),cone)
+      g241 = hp_glog((cone*(r2*r3*(-1 + xb) + (czip,1)*(r6 + xa*xb)))/((r2 - (czip,1)*r3)*r3*(-1 + r3**2)),(cone*(-(r6*xb) + xa*xb*(
+     &-1 + xa*(-1 + xb) + (-1 + xb)*xb) + r5*(r6 + xb*(-1 + xa + xb))))/((1 + xa)*(-1 + xb)*xb*(xa + xb)),cone)
+      g242 = hp_glog((cone*(r2*r3*(-1 + xb) + (czip,1)*(r6 + xa*xb)))/((r2 - (czip,1)*r3)*r3*(-1 + r3**2)),(cone*(-(r5*(r6 + xb*(-1 
+     &+ xa + xb))) + xb*(r6 + xa*(1 + xa*(-1 + xb) + (-1 + xb)*xb))))/((-1 + xa)*(-1 + xb)*xb*(xa + xb)),cone)
       g243 = hp_glog((-2*cone*(r6 + xa))/((xa + xb)*(-1 + xb**2)),cone,cone)
       g244 = hp_glog((-2*cone*(r6 + xa))/((xa + xb)*(-1 + xb**2)),-((cone*(r6 + xa))/((-1 + xb)*(xa + xb))),cone)
       g245 = hp_glog((-2*cone*(r6 + xa))/((xa + xb)*(-1 + xb**2)),(cone*(r6 + xa*xb))/(xb - xb**2),cone)
-      g246 = hp_glog((-2*cone*(r6 + xa))/((xa + xb)*(-1 + xb**2)),(cone*(-(r6*xb) + xa*xb*(-1 + xa*(-1 + xb) + (-1 + xb)*xb) - r5*(r6 + xb*(-1 + xa + xb))))/((1 + xa)*(-1 + xb)*xb*(xa + xb)),cone)
-      g247 = hp_glog((-2*cone*(r6 + xa))/((xa + xb)*(-1 + xb**2)),(cone*(r5*(r6 + xb*(-1 + xa + xb)) + xb*(r6 + xa*(1 + xa*(-1 + xb) + (-1 + xb)*xb))))/((-1 + xa)*(-1 + xb)*xb*(xa + xb)),cone)
-      g248 = hp_glog((-2*cone*(r6 + xa))/((xa + xb)*(-1 + xb**2)),(cone*(-(r6*xb) + xa*xb*(-1 + xa*(-1 + xb) + (-1 + xb)*xb) + r5*(r6 + xb*(-1 + xa + xb))))/((1 + xa)*(-1 + xb)*xb*(xa + xb)),cone)
-      g249 = hp_glog((-2*cone*(r6 + xa))/((xa + xb)*(-1 + xb**2)),(cone*(-(r5*(r6 + xb*(-1 + xa + xb))) + xb*(r6 + xa*(1 + xa*(-1 + xb) + (-1 + xb)*xb))))/((-1 + xa)*(-1 + xb)*xb*(xa + xb)),cone)
+      g246 = hp_glog((-2*cone*(r6 + xa))/((xa + xb)*(-1 + xb**2)),(cone*(-(r6*xb) + xa*xb*(-1 + xa*(-1 + xb) + (-1 + xb)*xb) - r5*(
+     &r6 + xb*(-1 + xa + xb))))/((1 + xa)*(-1 + xb)*xb*(xa + xb)),cone)
+      g247 = hp_glog((-2*cone*(r6 + xa))/((xa + xb)*(-1 + xb**2)),(cone*(r5*(r6 + xb*(-1 + xa + xb)) + xb*(r6 + xa*(1 + xa*(-1 + xb)
+     & + (-1 + xb)*xb))))/((-1 + xa)*(-1 + xb)*xb*(xa + xb)),cone)
+      g248 = hp_glog((-2*cone*(r6 + xa))/((xa + xb)*(-1 + xb**2)),(cone*(-(r6*xb) + xa*xb*(-1 + xa*(-1 + xb) + (-1 + xb)*xb) + r5*(
+     &r6 + xb*(-1 + xa + xb))))/((1 + xa)*(-1 + xb)*xb*(xa + xb)),cone)
+      g249 = hp_glog((-2*cone*(r6 + xa))/((xa + xb)*(-1 + xb**2)),(cone*(-(r5*(r6 + xb*(-1 + xa + xb))) + xb*(r6 + xa*(1 + xa*(-1 + 
+     &xb) + (-1 + xb)*xb))))/((-1 + xa)*(-1 + xb)*xb*(xa + xb)),cone)
       g250 = hp_glog((cone*(-r6 + xb))/(xb - xa*xb),czip,cone)
       g251 = hp_glog((cone*(-r6 + xb))/(xb - xa*xb),cone,cone)
       g252 = hp_glog((cone*(-r6 + xb))/(xb - xa*xb),(-2*cone)/(-1 + xa),cone)
@@ -1065,86 +1108,142 @@
       g263 = hp_glog((cone*(r6 + xa*xb))/(xb - xb**2),cone,cone)
       g264 = hp_glog((cone*(r6 + xa*xb))/(xb - xb**2),-((cone*(r6 + xa))/((-1 + xb)*(xa + xb))),cone)
       g265 = hp_glog((cone*(r6 + xa*xb))/(xb - xb**2),(cone*(r6 + xa*xb))/(xb - xb**2),cone)
-      g266 = hp_glog((cone*(r6 + xa*xb))/(xb - xb**2),(cone*(-(r6*xb) + xa*xb*(-1 + xa*(-1 + xb) + (-1 + xb)*xb) - r5*(r6 + xb*(-1 + xa + xb))))/((1 + xa)*(-1 + xb)*xb*(xa + xb)),cone)
-      g267 = hp_glog((cone*(r6 + xa*xb))/(xb - xb**2),(cone*(r5*(r6 + xb*(-1 + xa + xb)) + xb*(r6 + xa*(1 + xa*(-1 + xb) + (-1 + xb)*xb))))/((-1 + xa)*(-1 + xb)*xb*(xa + xb)),cone)
-      g268 = hp_glog((cone*(r6 + xa*xb))/(xb - xb**2),(cone*(-(r6*xb) + xa*xb*(-1 + xa*(-1 + xb) + (-1 + xb)*xb) + r5*(r6 + xb*(-1 + xa + xb))))/((1 + xa)*(-1 + xb)*xb*(xa + xb)),cone)
-      g269 = hp_glog((cone*(r6 + xa*xb))/(xb - xb**2),(cone*(-(r5*(r6 + xb*(-1 + xa + xb))) + xb*(r6 + xa*(1 + xa*(-1 + xb) + (-1 + xb)*xb))))/((-1 + xa)*(-1 + xb)*xb*(xa + xb)),cone)
+      g266 = hp_glog((cone*(r6 + xa*xb))/(xb - xb**2),(cone*(-(r6*xb) + xa*xb*(-1 + xa*(-1 + xb) + (-1 + xb)*xb) - r5*(r6 + xb*(-1 +
+     & xa + xb))))/((1 + xa)*(-1 + xb)*xb*(xa + xb)),cone)
+      g267 = hp_glog((cone*(r6 + xa*xb))/(xb - xb**2),(cone*(r5*(r6 + xb*(-1 + xa + xb)) + xb*(r6 + xa*(1 + xa*(-1 + xb) + (-1 + xb)
+     &*xb))))/((-1 + xa)*(-1 + xb)*xb*(xa + xb)),cone)
+      g268 = hp_glog((cone*(r6 + xa*xb))/(xb - xb**2),(cone*(-(r6*xb) + xa*xb*(-1 + xa*(-1 + xb) + (-1 + xb)*xb) + r5*(r6 + xb*(-1 +
+     & xa + xb))))/((1 + xa)*(-1 + xb)*xb*(xa + xb)),cone)
+      g269 = hp_glog((cone*(r6 + xa*xb))/(xb - xb**2),(cone*(-(r5*(r6 + xb*(-1 + xa + xb))) + xb*(r6 + xa*(1 + xa*(-1 + xb) + (-1 + 
+     &xb)*xb))))/((-1 + xa)*(-1 + xb)*xb*(xa + xb)),cone)
       g270 = hp_glog((-2*cone*(r6 + xa*xb))/(-1 + xb**2),cone,cone)
       g271 = hp_glog((-2*cone*(r6 + xa*xb))/(-1 + xb**2),-((cone*(r6 + xa))/((-1 + xb)*(xa + xb))),cone)
       g272 = hp_glog((-2*cone*(r6 + xa*xb))/(-1 + xb**2),(cone*(r6 + xa*xb))/(xb - xb**2),cone)
-      g273 = hp_glog((-2*cone*(r6 + xa*xb))/(-1 + xb**2),(cone*(-(r6*xb) + xa*xb*(-1 + xa*(-1 + xb) + (-1 + xb)*xb) - r5*(r6 + xb*(-1 + xa + xb))))/((1 + xa)*(-1 + xb)*xb*(xa + xb)),cone)
-      g274 = hp_glog((-2*cone*(r6 + xa*xb))/(-1 + xb**2),(cone*(r5*(r6 + xb*(-1 + xa + xb)) + xb*(r6 + xa*(1 + xa*(-1 + xb) + (-1 + xb)*xb))))/((-1 + xa)*(-1 + xb)*xb*(xa + xb)),cone)
-      g275 = hp_glog((-2*cone*(r6 + xa*xb))/(-1 + xb**2),(cone*(-(r6*xb) + xa*xb*(-1 + xa*(-1 + xb) + (-1 + xb)*xb) + r5*(r6 + xb*(-1 + xa + xb))))/((1 + xa)*(-1 + xb)*xb*(xa + xb)),cone)
-      g276 = hp_glog((-2*cone*(r6 + xa*xb))/(-1 + xb**2),(cone*(-(r5*(r6 + xb*(-1 + xa + xb))) + xb*(r6 + xa*(1 + xa*(-1 + xb) + (-1 + xb)*xb))))/((-1 + xa)*(-1 + xb)*xb*(xa + xb)),cone)
+      g273 = hp_glog((-2*cone*(r6 + xa*xb))/(-1 + xb**2),(cone*(-(r6*xb) + xa*xb*(-1 + xa*(-1 + xb) + (-1 + xb)*xb) - r5*(r6 + xb*(-
+     &1 + xa + xb))))/((1 + xa)*(-1 + xb)*xb*(xa + xb)),cone)
+      g274 = hp_glog((-2*cone*(r6 + xa*xb))/(-1 + xb**2),(cone*(r5*(r6 + xb*(-1 + xa + xb)) + xb*(r6 + xa*(1 + xa*(-1 + xb) + (-1 + 
+     &xb)*xb))))/((-1 + xa)*(-1 + xb)*xb*(xa + xb)),cone)
+      g275 = hp_glog((-2*cone*(r6 + xa*xb))/(-1 + xb**2),(cone*(-(r6*xb) + xa*xb*(-1 + xa*(-1 + xb) + (-1 + xb)*xb) + r5*(r6 + xb*(-
+     &1 + xa + xb))))/((1 + xa)*(-1 + xb)*xb*(xa + xb)),cone)
+      g276 = hp_glog((-2*cone*(r6 + xa*xb))/(-1 + xb**2),(cone*(-(r5*(r6 + xb*(-1 + xa + xb))) + xb*(r6 + xa*(1 + xa*(-1 + xb) + (-
+     &1 + xb)*xb))))/((-1 + xa)*(-1 + xb)*xb*(xa + xb)),cone)
       g277 = hp_glog((cone*(r6 - xa))/(r6 - xb*(-1 + xa + xb)),cone,cone)
       g278 = hp_glog((cone*(r6 - xa))/(r6 - xb*(-1 + xa + xb)),(cone*(r6 - xa))/(r6 - xb*(-1 + xa + xb)),cone)
       g279 = hp_glog((cone*(r6 - xa))/(r6 - xb*(-1 + xa + xb)),(cone*(r6 - xa*xb))/(r6 - xb*(-1 + xa + xb)),cone)
-      g280 = hp_glog((cone*(r6 - xa))/(r6 - xb*(-1 + xa + xb)),(cone*(-(r6*(1 + xa)) - r2*r3*r4*(-1 + xb) + xa*xb*(xa + xb)))/((1 + xa)*(-r6 + xb*(-1 + xa + xb))),cone)
-      g281 = hp_glog((cone*(r6 - xa))/(r6 - xb*(-1 + xa + xb)),(cone*(-(r6*(1 + xa)) + r2*r3*r4*(-1 + xb) + xa*xb*(xa + xb)))/((1 + xa)*(-r6 + xb*(-1 + xa + xb))),cone)
-      g282 = hp_glog((cone*(r6 - xa))/(r6 - xb*(-1 + xa + xb)),(cone*(r6 - r6*xa - r2*r3*r4*(-1 + xb) + xa*xb*(-2 + xa + xb)))/((-1 + xa)*(-r6 + xb*(-1 + xa + xb))),cone)
-      g283 = hp_glog((cone*(r6 - xa))/(r6 - xb*(-1 + xa + xb)),(cone*(r6 - r6*xa + r2*r3*r4*(-1 + xb) + xa*xb*(-2 + xa + xb)))/((-1 + xa)*(-r6 + xb*(-1 + xa + xb))),cone)
+      g280 = hp_glog((cone*(r6 - xa))/(r6 - xb*(-1 + xa + xb)),(cone*(-(r6*(1 + xa)) - r2*r3*r4*(-1 + xb) + xa*xb*(xa + xb)))/((1 + 
+     &xa)*(-r6 + xb*(-1 + xa + xb))),cone)
+      g281 = hp_glog((cone*(r6 - xa))/(r6 - xb*(-1 + xa + xb)),(cone*(-(r6*(1 + xa)) + r2*r3*r4*(-1 + xb) + xa*xb*(xa + xb)))/((1 + 
+     &xa)*(-r6 + xb*(-1 + xa + xb))),cone)
+      g282 = hp_glog((cone*(r6 - xa))/(r6 - xb*(-1 + xa + xb)),(cone*(r6 - r6*xa - r2*r3*r4*(-1 + xb) + xa*xb*(-2 + xa + xb)))/((-1 
+     &+ xa)*(-r6 + xb*(-1 + xa + xb))),cone)
+      g283 = hp_glog((cone*(r6 - xa))/(r6 - xb*(-1 + xa + xb)),(cone*(r6 - r6*xa + r2*r3*r4*(-1 + xb) + xa*xb*(-2 + xa + xb)))/((-1 
+     &+ xa)*(-r6 + xb*(-1 + xa + xb))),cone)
       g284 = hp_glog((cone*(r6 - xb))/(r6 - xb*(-1 + xa + xb)),cone,cone)
       g285 = hp_glog((cone*(r6 - xa*xb))/(r6 - xb*(-1 + xa + xb)),cone,cone)
       g286 = hp_glog((cone*(r6 - xa*xb))/(r6 - xb*(-1 + xa + xb)),(cone*(r6 - xa))/(r6 - xb*(-1 + xa + xb)),cone)
       g287 = hp_glog((cone*(r6 - xa*xb))/(r6 - xb*(-1 + xa + xb)),(cone*(r6 - xa*xb))/(r6 - xb*(-1 + xa + xb)),cone)
-      g288 = hp_glog((cone*(r6 - xa*xb))/(r6 - xb*(-1 + xa + xb)),(cone*(-(r6*(1 + xa)) - r2*r3*r4*(-1 + xb) + xa*xb*(xa + xb)))/((1 + xa)*(-r6 + xb*(-1 + xa + xb))),cone)
-      g289 = hp_glog((cone*(r6 - xa*xb))/(r6 - xb*(-1 + xa + xb)),(cone*(-(r6*(1 + xa)) + r2*r3*r4*(-1 + xb) + xa*xb*(xa + xb)))/((1 + xa)*(-r6 + xb*(-1 + xa + xb))),cone)
-      g290 = hp_glog((cone*(r6 - xa*xb))/(r6 - xb*(-1 + xa + xb)),(cone*(r6 - r6*xa - r2*r3*r4*(-1 + xb) + xa*xb*(-2 + xa + xb)))/((-1 + xa)*(-r6 + xb*(-1 + xa + xb))),cone)
-      g291 = hp_glog((cone*(r6 - xa*xb))/(r6 - xb*(-1 + xa + xb)),(cone*(r6 - r6*xa + r2*r3*r4*(-1 + xb) + xa*xb*(-2 + xa + xb)))/((-1 + xa)*(-r6 + xb*(-1 + xa + xb))),cone)
+      g288 = hp_glog((cone*(r6 - xa*xb))/(r6 - xb*(-1 + xa + xb)),(cone*(-(r6*(1 + xa)) - r2*r3*r4*(-1 + xb) + xa*xb*(xa + xb)))/((
+     &1 + xa)*(-r6 + xb*(-1 + xa + xb))),cone)
+      g289 = hp_glog((cone*(r6 - xa*xb))/(r6 - xb*(-1 + xa + xb)),(cone*(-(r6*(1 + xa)) + r2*r3*r4*(-1 + xb) + xa*xb*(xa + xb)))/((
+     &1 + xa)*(-r6 + xb*(-1 + xa + xb))),cone)
+      g290 = hp_glog((cone*(r6 - xa*xb))/(r6 - xb*(-1 + xa + xb)),(cone*(r6 - r6*xa - r2*r3*r4*(-1 + xb) + xa*xb*(-2 + xa + xb)))/((
+     &-1 + xa)*(-r6 + xb*(-1 + xa + xb))),cone)
+      g291 = hp_glog((cone*(r6 - xa*xb))/(r6 - xb*(-1 + xa + xb)),(cone*(r6 - r6*xa + r2*r3*r4*(-1 + xb) + xa*xb*(-2 + xa + xb)))/((
+     &-1 + xa)*(-r6 + xb*(-1 + xa + xb))),cone)
       g292 = hp_glog((cone*(r6 - (czip,1)*r2*r3*(-1 + xb) - xa*xb))/(r6 - xb*(-1 + xa + xb)),cone,cone)
-      g293 = hp_glog((cone*(r6 - (czip,1)*r2*r3*(-1 + xb) - xa*xb))/(r6 - xb*(-1 + xa + xb)),(cone*(r6 - xa))/(r6 - xb*(-1 + xa + xb)),cone)
-      g294 = hp_glog((cone*(r6 - (czip,1)*r2*r3*(-1 + xb) - xa*xb))/(r6 - xb*(-1 + xa + xb)),(cone*(r6 - xa*xb))/(r6 - xb*(-1 + xa + xb)),cone)
-      g295 = hp_glog((cone*(r6 - (czip,1)*r2*r3*(-1 + xb) - xa*xb))/(r6 - xb*(-1 + xa + xb)),(cone*(-(r6*(1 + xa)) - r2*r3*r4*(-1 + xb) + xa*xb*(xa + xb)))/((1 + xa)*(-r6 + xb*(-1 + xa + xb))),cone)
-      g296 = hp_glog((cone*(r6 - (czip,1)*r2*r3*(-1 + xb) - xa*xb))/(r6 - xb*(-1 + xa + xb)),(cone*(-(r6*(1 + xa)) + r2*r3*r4*(-1 + xb) + xa*xb*(xa + xb)))/((1 + xa)*(-r6 + xb*(-1 + xa + xb))),cone)
-      g297 = hp_glog((cone*(r6 - (czip,1)*r2*r3*(-1 + xb) - xa*xb))/(r6 - xb*(-1 + xa + xb)),(cone*(r6 - r6*xa - r2*r3*r4*(-1 + xb) + xa*xb*(-2 + xa + xb)))/((-1 + xa)*(-r6 + xb*(-1 + xa + xb))),cone)
-      g298 = hp_glog((cone*(r6 - (czip,1)*r2*r3*(-1 + xb) - xa*xb))/(r6 - xb*(-1 + xa + xb)),(cone*(r6 - r6*xa + r2*r3*r4*(-1 + xb) + xa*xb*(-2 + xa + xb)))/((-1 + xa)*(-r6 + xb*(-1 + xa + xb))),cone)
+      g293 = hp_glog((cone*(r6 - (czip,1)*r2*r3*(-1 + xb) - xa*xb))/(r6 - xb*(-1 + xa + xb)),(cone*(r6 - xa))/(r6 - xb*(-1 + xa + 
+     &xb)),cone)
+      g294 = hp_glog((cone*(r6 - (czip,1)*r2*r3*(-1 + xb) - xa*xb))/(r6 - xb*(-1 + xa + xb)),(cone*(r6 - xa*xb))/(r6 - xb*(-1 + xa +
+     & xb)),cone)
+      g295 = hp_glog((cone*(r6 - (czip,1)*r2*r3*(-1 + xb) - xa*xb))/(r6 - xb*(-1 + xa + xb)),(cone*(-(r6*(1 + xa)) - r2*r3*r4*(-1 + 
+     &xb) + xa*xb*(xa + xb)))/((1 + xa)*(-r6 + xb*(-1 + xa + xb))),cone)
+      g296 = hp_glog((cone*(r6 - (czip,1)*r2*r3*(-1 + xb) - xa*xb))/(r6 - xb*(-1 + xa + xb)),(cone*(-(r6*(1 + xa)) + r2*r3*r4*(-1 + 
+     &xb) + xa*xb*(xa + xb)))/((1 + xa)*(-r6 + xb*(-1 + xa + xb))),cone)
+      g297 = hp_glog((cone*(r6 - (czip,1)*r2*r3*(-1 + xb) - xa*xb))/(r6 - xb*(-1 + xa + xb)),(cone*(r6 - r6*xa - r2*r3*r4*(-1 + xb) 
+     &+ xa*xb*(-2 + xa + xb)))/((-1 + xa)*(-r6 + xb*(-1 + xa + xb))),cone)
+      g298 = hp_glog((cone*(r6 - (czip,1)*r2*r3*(-1 + xb) - xa*xb))/(r6 - xb*(-1 + xa + xb)),(cone*(r6 - r6*xa + r2*r3*r4*(-1 + xb) 
+     &+ xa*xb*(-2 + xa + xb)))/((-1 + xa)*(-r6 + xb*(-1 + xa + xb))),cone)
       g299 = hp_glog((cone*(r6 + (czip,1)*r2*r3*(-1 + xb) - xa*xb))/(r6 - xb*(-1 + xa + xb)),cone,cone)
-      g300 = hp_glog((cone*(r6 + (czip,1)*r2*r3*(-1 + xb) - xa*xb))/(r6 - xb*(-1 + xa + xb)),(cone*(r6 - xa))/(r6 - xb*(-1 + xa + xb)),cone)
-      g301 = hp_glog((cone*(r6 + (czip,1)*r2*r3*(-1 + xb) - xa*xb))/(r6 - xb*(-1 + xa + xb)),(cone*(r6 - xa*xb))/(r6 - xb*(-1 + xa + xb)),cone)
-      g302 = hp_glog((cone*(r6 + (czip,1)*r2*r3*(-1 + xb) - xa*xb))/(r6 - xb*(-1 + xa + xb)),(cone*(-(r6*(1 + xa)) - r2*r3*r4*(-1 + xb) + xa*xb*(xa + xb)))/((1 + xa)*(-r6 + xb*(-1 + xa + xb))),cone)
-      g303 = hp_glog((cone*(r6 + (czip,1)*r2*r3*(-1 + xb) - xa*xb))/(r6 - xb*(-1 + xa + xb)),(cone*(-(r6*(1 + xa)) + r2*r3*r4*(-1 + xb) + xa*xb*(xa + xb)))/((1 + xa)*(-r6 + xb*(-1 + xa + xb))),cone)
-      g304 = hp_glog((cone*(r6 + (czip,1)*r2*r3*(-1 + xb) - xa*xb))/(r6 - xb*(-1 + xa + xb)),(cone*(r6 - r6*xa - r2*r3*r4*(-1 + xb) + xa*xb*(-2 + xa + xb)))/((-1 + xa)*(-r6 + xb*(-1 + xa + xb))),cone)
-      g305 = hp_glog((cone*(r6 + (czip,1)*r2*r3*(-1 + xb) - xa*xb))/(r6 - xb*(-1 + xa + xb)),(cone*(r6 - r6*xa + r2*r3*r4*(-1 + xb) + xa*xb*(-2 + xa + xb)))/((-1 + xa)*(-r6 + xb*(-1 + xa + xb))),cone)
+      g300 = hp_glog((cone*(r6 + (czip,1)*r2*r3*(-1 + xb) - xa*xb))/(r6 - xb*(-1 + xa + xb)),(cone*(r6 - xa))/(r6 - xb*(-1 + xa + 
+     &xb)),cone)
+      g301 = hp_glog((cone*(r6 + (czip,1)*r2*r3*(-1 + xb) - xa*xb))/(r6 - xb*(-1 + xa + xb)),(cone*(r6 - xa*xb))/(r6 - xb*(-1 + xa +
+     & xb)),cone)
+      g302 = hp_glog((cone*(r6 + (czip,1)*r2*r3*(-1 + xb) - xa*xb))/(r6 - xb*(-1 + xa + xb)),(cone*(-(r6*(1 + xa)) - r2*r3*r4*(-1 + 
+     &xb) + xa*xb*(xa + xb)))/((1 + xa)*(-r6 + xb*(-1 + xa + xb))),cone)
+      g303 = hp_glog((cone*(r6 + (czip,1)*r2*r3*(-1 + xb) - xa*xb))/(r6 - xb*(-1 + xa + xb)),(cone*(-(r6*(1 + xa)) + r2*r3*r4*(-1 + 
+     &xb) + xa*xb*(xa + xb)))/((1 + xa)*(-r6 + xb*(-1 + xa + xb))),cone)
+      g304 = hp_glog((cone*(r6 + (czip,1)*r2*r3*(-1 + xb) - xa*xb))/(r6 - xb*(-1 + xa + xb)),(cone*(r6 - r6*xa - r2*r3*r4*(-1 + xb) 
+     &+ xa*xb*(-2 + xa + xb)))/((-1 + xa)*(-r6 + xb*(-1 + xa + xb))),cone)
+      g305 = hp_glog((cone*(r6 + (czip,1)*r2*r3*(-1 + xb) - xa*xb))/(r6 - xb*(-1 + xa + xb)),(cone*(r6 - r6*xa + r2*r3*r4*(-1 + xb) 
+     &+ xa*xb*(-2 + xa + xb)))/((-1 + xa)*(-r6 + xb*(-1 + xa + xb))),cone)
       g306 = hp_glog((cone*(-(r1*r2*r3) + r6))/(r6 - xb*(-1 + xa + xb)),cone,cone)
       g307 = hp_glog((cone*(-(r1*r2*r3) + r6))/(r6 - xb*(-1 + xa + xb)),(cone*(r6 - xa))/(r6 - xb*(-1 + xa + xb)),cone)
       g308 = hp_glog((cone*(-(r1*r2*r3) + r6))/(r6 - xb*(-1 + xa + xb)),(cone*(r6 - xa*xb))/(r6 - xb*(-1 + xa + xb)),cone)
-      g309 = hp_glog((cone*(-(r1*r2*r3) + r6))/(r6 - xb*(-1 + xa + xb)),(cone*(-(r6*(1 + xa)) - r2*r3*r4*(-1 + xb) + xa*xb*(xa + xb)))/((1 + xa)*(-r6 + xb*(-1 + xa + xb))),cone)
-      g310 = hp_glog((cone*(-(r1*r2*r3) + r6))/(r6 - xb*(-1 + xa + xb)),(cone*(-(r6*(1 + xa)) + r2*r3*r4*(-1 + xb) + xa*xb*(xa + xb)))/((1 + xa)*(-r6 + xb*(-1 + xa + xb))),cone)
-      g311 = hp_glog((cone*(-(r1*r2*r3) + r6))/(r6 - xb*(-1 + xa + xb)),(cone*(r6 - r6*xa - r2*r3*r4*(-1 + xb) + xa*xb*(-2 + xa + xb)))/((-1 + xa)*(-r6 + xb*(-1 + xa + xb))),cone)
-      g312 = hp_glog((cone*(-(r1*r2*r3) + r6))/(r6 - xb*(-1 + xa + xb)),(cone*(r6 - r6*xa + r2*r3*r4*(-1 + xb) + xa*xb*(-2 + xa + xb)))/((-1 + xa)*(-r6 + xb*(-1 + xa + xb))),cone)
+      g309 = hp_glog((cone*(-(r1*r2*r3) + r6))/(r6 - xb*(-1 + xa + xb)),(cone*(-(r6*(1 + xa)) - r2*r3*r4*(-1 + xb) + xa*xb*(xa + xb)
+     &))/((1 + xa)*(-r6 + xb*(-1 + xa + xb))),cone)
+      g310 = hp_glog((cone*(-(r1*r2*r3) + r6))/(r6 - xb*(-1 + xa + xb)),(cone*(-(r6*(1 + xa)) + r2*r3*r4*(-1 + xb) + xa*xb*(xa + xb)
+     &))/((1 + xa)*(-r6 + xb*(-1 + xa + xb))),cone)
+      g311 = hp_glog((cone*(-(r1*r2*r3) + r6))/(r6 - xb*(-1 + xa + xb)),(cone*(r6 - r6*xa - r2*r3*r4*(-1 + xb) + xa*xb*(-2 + xa + 
+     &xb)))/((-1 + xa)*(-r6 + xb*(-1 + xa + xb))),cone)
+      g312 = hp_glog((cone*(-(r1*r2*r3) + r6))/(r6 - xb*(-1 + xa + xb)),(cone*(r6 - r6*xa + r2*r3*r4*(-1 + xb) + xa*xb*(-2 + xa + 
+     &xb)))/((-1 + xa)*(-r6 + xb*(-1 + xa + xb))),cone)
       g313 = hp_glog((cone*(r1*r2*r3 + r6))/(r6 - xb*(-1 + xa + xb)),cone,cone)
       g314 = hp_glog((cone*(r1*r2*r3 + r6))/(r6 - xb*(-1 + xa + xb)),(cone*(r6 - xa))/(r6 - xb*(-1 + xa + xb)),cone)
       g315 = hp_glog((cone*(r1*r2*r3 + r6))/(r6 - xb*(-1 + xa + xb)),(cone*(r6 - xa*xb))/(r6 - xb*(-1 + xa + xb)),cone)
-      g316 = hp_glog((cone*(r1*r2*r3 + r6))/(r6 - xb*(-1 + xa + xb)),(cone*(-(r6*(1 + xa)) - r2*r3*r4*(-1 + xb) + xa*xb*(xa + xb)))/((1 + xa)*(-r6 + xb*(-1 + xa + xb))),cone)
-      g317 = hp_glog((cone*(r1*r2*r3 + r6))/(r6 - xb*(-1 + xa + xb)),(cone*(-(r6*(1 + xa)) + r2*r3*r4*(-1 + xb) + xa*xb*(xa + xb)))/((1 + xa)*(-r6 + xb*(-1 + xa + xb))),cone)
-      g318 = hp_glog((cone*(r1*r2*r3 + r6))/(r6 - xb*(-1 + xa + xb)),(cone*(r6 - r6*xa - r2*r3*r4*(-1 + xb) + xa*xb*(-2 + xa + xb)))/((-1 + xa)*(-r6 + xb*(-1 + xa + xb))),cone)
-      g319 = hp_glog((cone*(r1*r2*r3 + r6))/(r6 - xb*(-1 + xa + xb)),(cone*(r6 - r6*xa + r2*r3*r4*(-1 + xb) + xa*xb*(-2 + xa + xb)))/((-1 + xa)*(-r6 + xb*(-1 + xa + xb))),cone)
+      g316 = hp_glog((cone*(r1*r2*r3 + r6))/(r6 - xb*(-1 + xa + xb)),(cone*(-(r6*(1 + xa)) - r2*r3*r4*(-1 + xb) + xa*xb*(xa + xb)))/
+     &((1 + xa)*(-r6 + xb*(-1 + xa + xb))),cone)
+      g317 = hp_glog((cone*(r1*r2*r3 + r6))/(r6 - xb*(-1 + xa + xb)),(cone*(-(r6*(1 + xa)) + r2*r3*r4*(-1 + xb) + xa*xb*(xa + xb)))/
+     &((1 + xa)*(-r6 + xb*(-1 + xa + xb))),cone)
+      g318 = hp_glog((cone*(r1*r2*r3 + r6))/(r6 - xb*(-1 + xa + xb)),(cone*(r6 - r6*xa - r2*r3*r4*(-1 + xb) + xa*xb*(-2 + xa + xb)))
+     &/((-1 + xa)*(-r6 + xb*(-1 + xa + xb))),cone)
+      g319 = hp_glog((cone*(r1*r2*r3 + r6))/(r6 - xb*(-1 + xa + xb)),(cone*(r6 - r6*xa + r2*r3*r4*(-1 + xb) + xa*xb*(-2 + xa + xb)))
+     &/((-1 + xa)*(-r6 + xb*(-1 + xa + xb))),cone)
       g320 = hp_glog((cone*(r1*r2*r3*(-1 + xb) + 2*xa*xb - r6*(1 + xb)))/((1 + xb)*(-r6 + xb*(-1 + xa + xb))),cone,cone)
-      g321 = hp_glog((cone*(r1*r2*r3*(-1 + xb) + 2*xa*xb - r6*(1 + xb)))/((1 + xb)*(-r6 + xb*(-1 + xa + xb))),(cone*(r6 - xa))/(r6 - xb*(-1 + xa + xb)),cone)
-      g322 = hp_glog((cone*(r1*r2*r3*(-1 + xb) + 2*xa*xb - r6*(1 + xb)))/((1 + xb)*(-r6 + xb*(-1 + xa + xb))),(cone*(r6 - xa*xb))/(r6 - xb*(-1 + xa + xb)),cone)
-      g323 = hp_glog((cone*(r1*r2*r3*(-1 + xb) + 2*xa*xb - r6*(1 + xb)))/((1 + xb)*(-r6 + xb*(-1 + xa + xb))),(cone*(-(r6*(1 + xa)) - r2*r3*r4*(-1 + xb) + xa*xb*(xa + xb)))/((1 + xa)*(-r6 + xb*(-1 + xa + xb))),cone)
-      g324 = hp_glog((cone*(r1*r2*r3*(-1 + xb) + 2*xa*xb - r6*(1 + xb)))/((1 + xb)*(-r6 + xb*(-1 + xa + xb))),(cone*(-(r6*(1 + xa)) + r2*r3*r4*(-1 + xb) + xa*xb*(xa + xb)))/((1 + xa)*(-r6 + xb*(-1 + xa + xb))),cone)
-      g325 = hp_glog((cone*(r1*r2*r3*(-1 + xb) + 2*xa*xb - r6*(1 + xb)))/((1 + xb)*(-r6 + xb*(-1 + xa + xb))),(cone*(r6 - r6*xa - r2*r3*r4*(-1 + xb) + xa*xb*(-2 + xa + xb)))/((-1 + xa)*(-r6 + xb*(-1 + xa + xb))),cone)
-      g326 = hp_glog((cone*(r1*r2*r3*(-1 + xb) + 2*xa*xb - r6*(1 + xb)))/((1 + xb)*(-r6 + xb*(-1 + xa + xb))),(cone*(r6 - r6*xa + r2*r3*r4*(-1 + xb) + xa*xb*(-2 + xa + xb)))/((-1 + xa)*(-r6 + xb*(-1 + xa + xb))),cone)
+      g321 = hp_glog((cone*(r1*r2*r3*(-1 + xb) + 2*xa*xb - r6*(1 + xb)))/((1 + xb)*(-r6 + xb*(-1 + xa + xb))),(cone*(r6 - xa))/(r6 -
+     & xb*(-1 + xa + xb)),cone)
+      g322 = hp_glog((cone*(r1*r2*r3*(-1 + xb) + 2*xa*xb - r6*(1 + xb)))/((1 + xb)*(-r6 + xb*(-1 + xa + xb))),(cone*(r6 - xa*xb))/(
+     &r6 - xb*(-1 + xa + xb)),cone)
+      g323 = hp_glog((cone*(r1*r2*r3*(-1 + xb) + 2*xa*xb - r6*(1 + xb)))/((1 + xb)*(-r6 + xb*(-1 + xa + xb))),(cone*(-(r6*(1 + xa)) 
+     &- r2*r3*r4*(-1 + xb) + xa*xb*(xa + xb)))/((1 + xa)*(-r6 + xb*(-1 + xa + xb))),cone)
+      g324 = hp_glog((cone*(r1*r2*r3*(-1 + xb) + 2*xa*xb - r6*(1 + xb)))/((1 + xb)*(-r6 + xb*(-1 + xa + xb))),(cone*(-(r6*(1 + xa)) 
+     &+ r2*r3*r4*(-1 + xb) + xa*xb*(xa + xb)))/((1 + xa)*(-r6 + xb*(-1 + xa + xb))),cone)
+      g325 = hp_glog((cone*(r1*r2*r3*(-1 + xb) + 2*xa*xb - r6*(1 + xb)))/((1 + xb)*(-r6 + xb*(-1 + xa + xb))),(cone*(r6 - r6*xa - 
+     &r2*r3*r4*(-1 + xb) + xa*xb*(-2 + xa + xb)))/((-1 + xa)*(-r6 + xb*(-1 + xa + xb))),cone)
+      g326 = hp_glog((cone*(r1*r2*r3*(-1 + xb) + 2*xa*xb - r6*(1 + xb)))/((1 + xb)*(-r6 + xb*(-1 + xa + xb))),(cone*(r6 - r6*xa + 
+     &r2*r3*r4*(-1 + xb) + xa*xb*(-2 + xa + xb)))/((-1 + xa)*(-r6 + xb*(-1 + xa + xb))),cone)
       g327 = hp_glog(-((cone*(r6 + r1*r2*r3*(-1 + xb) + r6*xb - 2*xa*xb))/((1 + xb)*(-r6 + xb*(-1 + xa + xb)))),cone,cone)
-      g328 = hp_glog(-((cone*(r6 + r1*r2*r3*(-1 + xb) + r6*xb - 2*xa*xb))/((1 + xb)*(-r6 + xb*(-1 + xa + xb)))),(cone*(r6 - xa))/(r6 - xb*(-1 + xa + xb)),cone)
-      g329 = hp_glog(-((cone*(r6 + r1*r2*r3*(-1 + xb) + r6*xb - 2*xa*xb))/((1 + xb)*(-r6 + xb*(-1 + xa + xb)))),(cone*(r6 - xa*xb))/(r6 - xb*(-1 + xa + xb)),cone)
-      g330 = hp_glog(-((cone*(r6 + r1*r2*r3*(-1 + xb) + r6*xb - 2*xa*xb))/((1 + xb)*(-r6 + xb*(-1 + xa + xb)))),(cone*(-(r6*(1 + xa)) - r2*r3*r4*(-1 + xb) + xa*xb*(xa + xb)))/((1 + xa)*(-r6 + xb*(-1 + xa + xb))),cone)
-      g331 = hp_glog(-((cone*(r6 + r1*r2*r3*(-1 + xb) + r6*xb - 2*xa*xb))/((1 + xb)*(-r6 + xb*(-1 + xa + xb)))),(cone*(-(r6*(1 + xa)) + r2*r3*r4*(-1 + xb) + xa*xb*(xa + xb)))/((1 + xa)*(-r6 + xb*(-1 + xa + xb))),cone)
-      g332 = hp_glog(-((cone*(r6 + r1*r2*r3*(-1 + xb) + r6*xb - 2*xa*xb))/((1 + xb)*(-r6 + xb*(-1 + xa + xb)))),(cone*(r6 - r6*xa - r2*r3*r4*(-1 + xb) + xa*xb*(-2 + xa + xb)))/((-1 + xa)*(-r6 + xb*(-1 + xa + xb))),cone)
-      g333 = hp_glog(-((cone*(r6 + r1*r2*r3*(-1 + xb) + r6*xb - 2*xa*xb))/((1 + xb)*(-r6 + xb*(-1 + xa + xb)))),(cone*(r6 - r6*xa + r2*r3*r4*(-1 + xb) + xa*xb*(-2 + xa + xb)))/((-1 + xa)*(-r6 + xb*(-1 + xa + xb))),cone)
-      g334 = hp_glog((cone*(-xa + xb - r6*(-2 + xa + xb) + (-1 + xa)*xb*(xa + xb)))/((-2 + xa + xb)*(-r6 + xb*(-1 + xa + xb))),cone,cone)
+      g328 = hp_glog(-((cone*(r6 + r1*r2*r3*(-1 + xb) + r6*xb - 2*xa*xb))/((1 + xb)*(-r6 + xb*(-1 + xa + xb)))),(cone*(r6 - xa))/(
+     &r6 - xb*(-1 + xa + xb)),cone)
+      g329 = hp_glog(-((cone*(r6 + r1*r2*r3*(-1 + xb) + r6*xb - 2*xa*xb))/((1 + xb)*(-r6 + xb*(-1 + xa + xb)))),(cone*(r6 - xa*xb))/
+     &(r6 - xb*(-1 + xa + xb)),cone)
+      g330 = hp_glog(-((cone*(r6 + r1*r2*r3*(-1 + xb) + r6*xb - 2*xa*xb))/((1 + xb)*(-r6 + xb*(-1 + xa + xb)))),(cone*(-(r6*(1 + xa)
+     &) - r2*r3*r4*(-1 + xb) + xa*xb*(xa + xb)))/((1 + xa)*(-r6 + xb*(-1 + xa + xb))),cone)
+      g331 = hp_glog(-((cone*(r6 + r1*r2*r3*(-1 + xb) + r6*xb - 2*xa*xb))/((1 + xb)*(-r6 + xb*(-1 + xa + xb)))),(cone*(-(r6*(1 + xa)
+     &) + r2*r3*r4*(-1 + xb) + xa*xb*(xa + xb)))/((1 + xa)*(-r6 + xb*(-1 + xa + xb))),cone)
+      g332 = hp_glog(-((cone*(r6 + r1*r2*r3*(-1 + xb) + r6*xb - 2*xa*xb))/((1 + xb)*(-r6 + xb*(-1 + xa + xb)))),(cone*(r6 - r6*xa - 
+     &r2*r3*r4*(-1 + xb) + xa*xb*(-2 + xa + xb)))/((-1 + xa)*(-r6 + xb*(-1 + xa + xb))),cone)
+      g333 = hp_glog(-((cone*(r6 + r1*r2*r3*(-1 + xb) + r6*xb - 2*xa*xb))/((1 + xb)*(-r6 + xb*(-1 + xa + xb)))),(cone*(r6 - r6*xa + 
+     &r2*r3*r4*(-1 + xb) + xa*xb*(-2 + xa + xb)))/((-1 + xa)*(-r6 + xb*(-1 + xa + xb))),cone)
+      g334 = hp_glog((cone*(-xa + xb - r6*(-2 + xa + xb) + (-1 + xa)*xb*(xa + xb)))/((-2 + xa + xb)*(-r6 + xb*(-1 + xa + xb))),cone,
+     &cone)
       g335 = hp_glog((-2*cone*(r6*(-1 + xa + xb) + xa*(-1 + xb*(xa + xb))))/((-1 + xb)**2*(xa + xb)),cone,cone)
-      g336 = hp_glog((-2*cone*(r6*(-1 + xa + xb) + xa*(-1 + xb*(xa + xb))))/((-1 + xb)**2*(xa + xb)),-((cone*(r6 + xa))/((-1 + xb)*(xa + xb))),cone)
-      g337 = hp_glog((-2*cone*(r6*(-1 + xa + xb) + xa*(-1 + xb*(xa + xb))))/((-1 + xb)**2*(xa + xb)),(cone*(r6 + xa*xb))/(xb - xb**2),cone)
-      g338 = hp_glog((-2*cone*(r6*(-1 + xa + xb) + xa*(-1 + xb*(xa + xb))))/((-1 + xb)**2*(xa + xb)),(cone*(-(r6*xb) + xa*xb*(-1 + xa*(-1 + xb) + (-1 + xb)*xb) - r5*(r6 + xb*(-1 + xa + xb))))/((1 + xa)*(-1 + xb)*xb*(xa + xb)),cone)
-      g339 = hp_glog((-2*cone*(r6*(-1 + xa + xb) + xa*(-1 + xb*(xa + xb))))/((-1 + xb)**2*(xa + xb)),(cone*(r5*(r6 + xb*(-1 + xa + xb)) + xb*(r6 + xa*(1 + xa*(-1 + xb) + (-1 + xb)*xb))))/((-1 + xa)*(-1 + xb)*xb*(xa + xb)),cone)
-      g340 = hp_glog((-2*cone*(r6*(-1 + xa + xb) + xa*(-1 + xb*(xa + xb))))/((-1 + xb)**2*(xa + xb)),(cone*(-(r6*xb) + xa*xb*(-1 + xa*(-1 + xb) + (-1 + xb)*xb) + r5*(r6 + xb*(-1 + xa + xb))))/((1 + xa)*(-1 + xb)*xb*(xa + xb)),cone)
-      g341 = hp_glog((-2*cone*(r6*(-1 + xa + xb) + xa*(-1 + xb*(xa + xb))))/((-1 + xb)**2*(xa + xb)),(cone*(-(r5*(r6 + xb*(-1 + xa + xb))) + xb*(r6 + xa*(1 + xa*(-1 + xb) + (-1 + xb)*xb))))/((-1 + xa)*(-1 + xb)*xb*(xa + xb)),cone)
+      g336 = hp_glog((-2*cone*(r6*(-1 + xa + xb) + xa*(-1 + xb*(xa + xb))))/((-1 + xb)**2*(xa + xb)),-((cone*(r6 + xa))/((-1 + xb)*(
+     &xa + xb))),cone)
+      g337 = hp_glog((-2*cone*(r6*(-1 + xa + xb) + xa*(-1 + xb*(xa + xb))))/((-1 + xb)**2*(xa + xb)),(cone*(r6 + xa*xb))/(xb - 
+     &xb**2),cone)
+      g338 = hp_glog((-2*cone*(r6*(-1 + xa + xb) + xa*(-1 + xb*(xa + xb))))/((-1 + xb)**2*(xa + xb)),(cone*(-(r6*xb) + xa*xb*(-1 + 
+     &xa*(-1 + xb) + (-1 + xb)*xb) - r5*(r6 + xb*(-1 + xa + xb))))/((1 + xa)*(-1 + xb)*xb*(xa + xb)),cone)
+      g339 = hp_glog((-2*cone*(r6*(-1 + xa + xb) + xa*(-1 + xb*(xa + xb))))/((-1 + xb)**2*(xa + xb)),(cone*(r5*(r6 + xb*(-1 + xa + 
+     &xb)) + xb*(r6 + xa*(1 + xa*(-1 + xb) + (-1 + xb)*xb))))/((-1 + xa)*(-1 + xb)*xb*(xa + xb)),cone)
+      g340 = hp_glog((-2*cone*(r6*(-1 + xa + xb) + xa*(-1 + xb*(xa + xb))))/((-1 + xb)**2*(xa + xb)),(cone*(-(r6*xb) + xa*xb*(-1 + 
+     &xa*(-1 + xb) + (-1 + xb)*xb) + r5*(r6 + xb*(-1 + xa + xb))))/((1 + xa)*(-1 + xb)*xb*(xa + xb)),cone)
+      g341 = hp_glog((-2*cone*(r6*(-1 + xa + xb) + xa*(-1 + xb*(xa + xb))))/((-1 + xb)**2*(xa + xb)),(cone*(-(r5*(r6 + xb*(-1 + xa +
+     & xb))) + xb*(r6 + xa*(1 + xa*(-1 + xb) + (-1 + xb)*xb))))/((-1 + xa)*(-1 + xb)*xb*(xa + xb)),cone)
       g342 = hp_glog(-((cone*(-xa + xb + r6*(-2 + xa + xb) + (-1 + xa)*xb*(xa + xb)))/((-1 + xb)**2*(xa + xb))),cone,cone)
       g343 = hp_glog((cone*(-r7 - r8*r9 + r2*r3*(xa + xb)))/2.0_ki,(cone*(-r10 + r2))/r3,(cone*r11)/Sqrt((r2 + 1/Sqrt(xa + xb))/r2))
       g344 = hp_glog((cone*(-r7 - r8*r9 + r2*r3*(xa + xb)))/2.0_ki,(cone*(-r10 + r2))/r3,(cone*r12)/Sqrt(1 + r2/Sqrt(xa + xb)))
-      g345 = hp_glog((cone*(-r7 - r8*r9 + r2*r3*(xa + xb)))/2.0_ki,-((cone*(r10 + r2))/r3),(cone*r11)/Sqrt((r2 + 1/Sqrt(xa + xb))/r2))
+      g345 = hp_glog((cone*(-r7 - r8*r9 + r2*r3*(xa + xb)))/2.0_ki,-((cone*(r10 + r2))/r3),(cone*r11)/Sqrt((r2 + 1/Sqrt(xa + xb))/
+     &r2))
       g346 = hp_glog((cone*(-r7 - r8*r9 + r2*r3*(xa + xb)))/2.0_ki,-((cone*(r10 + r2))/r3),(cone*r12)/Sqrt(1 + r2/Sqrt(xa + xb)))
       g347 = hp_glog((cone*(-r7 - r8*r9 + r2*r3*(xa + xb)))/2.0_ki,-(cone*r13),(cone*r11)/Sqrt((r2 + 1/Sqrt(xa + xb))/r2))
       g348 = hp_glog((cone*(-r7 - r8*r9 + r2*r3*(xa + xb)))/2.0_ki,-(cone*r13),(cone*r12)/Sqrt(1 + r2/Sqrt(xa + xb)))
@@ -1176,7 +1275,8 @@
       g374 = hp_glog((cone*(r7 - r8*r9 - r2*r3*(xa + xb)))/2.0_ki,cone*(r1 + r10*r3),(cone*r12)/Sqrt(1 + r2/Sqrt(xa + xb)))
       g375 = hp_glog((cone*(-r7 + r8*r9 + r2*r3*(xa + xb)))/2.0_ki,(cone*(-r10 + r2))/r3,(cone*r11)/Sqrt((r2 + 1/Sqrt(xa + xb))/r2))
       g376 = hp_glog((cone*(-r7 + r8*r9 + r2*r3*(xa + xb)))/2.0_ki,(cone*(-r10 + r2))/r3,(cone*r12)/Sqrt(1 + r2/Sqrt(xa + xb)))
-      g377 = hp_glog((cone*(-r7 + r8*r9 + r2*r3*(xa + xb)))/2.0_ki,-((cone*(r10 + r2))/r3),(cone*r11)/Sqrt((r2 + 1/Sqrt(xa + xb))/r2))
+      g377 = hp_glog((cone*(-r7 + r8*r9 + r2*r3*(xa + xb)))/2.0_ki,-((cone*(r10 + r2))/r3),(cone*r11)/Sqrt((r2 + 1/Sqrt(xa + xb))/
+     &r2))
       g378 = hp_glog((cone*(-r7 + r8*r9 + r2*r3*(xa + xb)))/2.0_ki,-((cone*(r10 + r2))/r3),(cone*r12)/Sqrt(1 + r2/Sqrt(xa + xb)))
       g379 = hp_glog((cone*(-r7 + r8*r9 + r2*r3*(xa + xb)))/2.0_ki,-(cone*r13),(cone*r11)/Sqrt((r2 + 1/Sqrt(xa + xb))/r2))
       g380 = hp_glog((cone*(-r7 + r8*r9 + r2*r3*(xa + xb)))/2.0_ki,-(cone*r13),(cone*r12)/Sqrt(1 + r2/Sqrt(xa + xb)))
@@ -1224,7 +1324,8 @@
       g422 = hp_glog((cone*(-r7 - r15*r8 - r2*r3*(xa + xb)))/2.0_ki,cone*(r1 + r10*r3),(cone*r12)/Sqrt(1 + r2/Sqrt(xa + xb)))
       g423 = hp_glog((cone*(r7 - r15*r8 + r2*r3*(xa + xb)))/2.0_ki,(cone*(-r10 + r2))/r3,(cone*r11)/Sqrt((r2 + 1/Sqrt(xa + xb))/r2))
       g424 = hp_glog((cone*(r7 - r15*r8 + r2*r3*(xa + xb)))/2.0_ki,(cone*(-r10 + r2))/r3,(cone*r12)/Sqrt(1 + r2/Sqrt(xa + xb)))
-      g425 = hp_glog((cone*(r7 - r15*r8 + r2*r3*(xa + xb)))/2.0_ki,-((cone*(r10 + r2))/r3),(cone*r11)/Sqrt((r2 + 1/Sqrt(xa + xb))/r2))
+      g425 = hp_glog((cone*(r7 - r15*r8 + r2*r3*(xa + xb)))/2.0_ki,-((cone*(r10 + r2))/r3),(cone*r11)/Sqrt((r2 + 1/Sqrt(xa + xb))/
+     &r2))
       g426 = hp_glog((cone*(r7 - r15*r8 + r2*r3*(xa + xb)))/2.0_ki,-((cone*(r10 + r2))/r3),(cone*r12)/Sqrt(1 + r2/Sqrt(xa + xb)))
       g427 = hp_glog((cone*(r7 - r15*r8 + r2*r3*(xa + xb)))/2.0_ki,-(cone*r13),(cone*r11)/Sqrt((r2 + 1/Sqrt(xa + xb))/r2))
       g428 = hp_glog((cone*(r7 - r15*r8 + r2*r3*(xa + xb)))/2.0_ki,-(cone*r13),(cone*r12)/Sqrt(1 + r2/Sqrt(xa + xb)))
@@ -1256,7 +1357,8 @@
       g454 = hp_glog((cone*(-r7 + r15*r8 - r2*r3*(xa + xb)))/2.0_ki,cone*(r1 + r10*r3),(cone*r12)/Sqrt(1 + r2/Sqrt(xa + xb)))
       g455 = hp_glog((cone*(r7 + r15*r8 + r2*r3*(xa + xb)))/2.0_ki,(cone*(-r10 + r2))/r3,(cone*r11)/Sqrt((r2 + 1/Sqrt(xa + xb))/r2))
       g456 = hp_glog((cone*(r7 + r15*r8 + r2*r3*(xa + xb)))/2.0_ki,(cone*(-r10 + r2))/r3,(cone*r12)/Sqrt(1 + r2/Sqrt(xa + xb)))
-      g457 = hp_glog((cone*(r7 + r15*r8 + r2*r3*(xa + xb)))/2.0_ki,-((cone*(r10 + r2))/r3),(cone*r11)/Sqrt((r2 + 1/Sqrt(xa + xb))/r2))
+      g457 = hp_glog((cone*(r7 + r15*r8 + r2*r3*(xa + xb)))/2.0_ki,-((cone*(r10 + r2))/r3),(cone*r11)/Sqrt((r2 + 1/Sqrt(xa + xb))/
+     &r2))
       g458 = hp_glog((cone*(r7 + r15*r8 + r2*r3*(xa + xb)))/2.0_ki,-((cone*(r10 + r2))/r3),(cone*r12)/Sqrt(1 + r2/Sqrt(xa + xb)))
       g459 = hp_glog((cone*(r7 + r15*r8 + r2*r3*(xa + xb)))/2.0_ki,-(cone*r13),(cone*r11)/Sqrt((r2 + 1/Sqrt(xa + xb))/r2))
       g460 = hp_glog((cone*(r7 + r15*r8 + r2*r3*(xa + xb)))/2.0_ki,-(cone*r13),(cone*r12)/Sqrt(1 + r2/Sqrt(xa + xb)))

--- a/src/hp_Intcts/include/hp_a2carbs_bulk_functions.h
+++ b/src/hp_Intcts/include/hp_a2carbs_bulk_functions.h
@@ -330,36 +330,58 @@
       g108 = hp_glog((cone*(1 + xa)*xb)/(xa*(-1 + xb)),czip,cone)
       g109 = hp_glog((cone*(1 + xa)*xb)/(xa*(-1 + xb)),cone,cone)
       g110 = hp_glog((cone*(1 + xa)*xb)/(xa*(-1 + xb)),(cone*(1 + xa)*(1 + xb))/((-1 + xa)*(-1 + xb)),cone)
-      g111 = hp_glog((cone*(1 + xa)*xb)/(xa*(-1 + xb)),(cone*(-(r1*(1 - xb)) + xa**2*(-1 + xb)*xb))/((-1 + xa)*xa*(-1 + xb)**2),cone)
+      g111 = hp_glog((cone*(1 + xa)*xb)/(xa*(-1 + xb)),(cone*(-(r1*(1 - xb)) + xa**2*(-1 + xb)*xb))/((-1 + xa)*xa*(-1 + xb)**2),
+     &cone)
       g112 = hp_glog((cone*(1 + xa)*xb)/(xa*(-1 + xb)),(cone*(r1*(1 - xb) + xa**2*(-1 + xb)*xb))/((-1 + xa)*xa*(-1 + xb)**2),cone)
       g113 = hp_glog((cone*xa*(1 + xb))/((-1 + xa)*xb),czip,cone)
       g114 = hp_glog((cone*xa*(1 + xb))/((-1 + xa)*xb),cone,cone)
       g115 = hp_glog((cone*xa*(1 + xb))/((-1 + xa)*xb),(cone*(1 + xa)*(1 + xb))/((-1 + xa)*(-1 + xb)),cone)
-      g116 = hp_glog((cone*xa*(1 + xb))/((-1 + xa)*xb),-((cone*(r2*(1 - xa) + xa*xb**2 - xa**2*xb**2))/((-1 + xa)**2*(-1 + xb)*xb)),cone)
-      g117 = hp_glog((cone*xa*(1 + xb))/((-1 + xa)*xb),(cone*(r2*(1 - xa) - xa*xb**2 + xa**2*xb**2))/((-1 + xa)**2*(-1 + xb)*xb),cone)
+      g116 = hp_glog((cone*xa*(1 + xb))/((-1 + xa)*xb),-((cone*(r2*(1 - xa) + xa*xb**2 - xa**2*xb**2))/((-1 + xa)**2*(-1 + xb)*xb)),
+     &cone)
+      g117 = hp_glog((cone*xa*(1 + xb))/((-1 + xa)*xb),(cone*(r2*(1 - xa) - xa*xb**2 + xa**2*xb**2))/((-1 + xa)**2*(-1 + xb)*xb),
+     &cone)
       g118 = hp_glog((cone*(-1 + xa*xb))/((-1 + xa)*(-1 + xb)),(cone*(1 + xa)*xb)/(xa*(-1 + xb)),cone)
       g119 = hp_glog((cone*(-1 + xa*xb))/((-1 + xa)*(-1 + xb)),(cone*xa*(1 + xb))/((-1 + xa)*xb),cone)
-      g120 = hp_glog((cone*(-1 + xa*xb))/((-1 + xa)*(-1 + xb)),(cone*(-(r1*(1 - xb)) + xa**2*(-1 + xb)*xb))/((-1 + xa)*xa*(-1 + xb)**2),cone)
-      g121 = hp_glog((cone*(-1 + xa*xb))/((-1 + xa)*(-1 + xb)),(cone*(r1*(1 - xb) + xa**2*(-1 + xb)*xb))/((-1 + xa)*xa*(-1 + xb)**2),cone)
-      g122 = hp_glog((cone*(-1 + xa*xb))/((-1 + xa)*(-1 + xb)),-((cone*(r2*(1 - xa) + xa*xb**2 - xa**2*xb**2))/((-1 + xa)**2*(-1 + xb)*xb)),cone)
-      g123 = hp_glog((cone*(-1 + xa*xb))/((-1 + xa)*(-1 + xb)),(cone*(r2*(1 - xa) - xa*xb**2 + xa**2*xb**2))/((-1 + xa)**2*(-1 + xb)*xb),cone)
+      g120 = hp_glog((cone*(-1 + xa*xb))/((-1 + xa)*(-1 + xb)),(cone*(-(r1*(1 - xb)) + xa**2*(-1 + xb)*xb))/((-1 + xa)*xa*(-1 + xb)
+     &**2),cone)
+      g121 = hp_glog((cone*(-1 + xa*xb))/((-1 + xa)*(-1 + xb)),(cone*(r1*(1 - xb) + xa**2*(-1 + xb)*xb))/((-1 + xa)*xa*(-1 + xb)**2)
+     &,cone)
+      g122 = hp_glog((cone*(-1 + xa*xb))/((-1 + xa)*(-1 + xb)),-((cone*(r2*(1 - xa) + xa*xb**2 - xa**2*xb**2))/((-1 + xa)**2*(-1 + 
+     &xb)*xb)),cone)
+      g123 = hp_glog((cone*(-1 + xa*xb))/((-1 + xa)*(-1 + xb)),(cone*(r2*(1 - xa) - xa*xb**2 + xa**2*xb**2))/((-1 + xa)**2*(-1 + xb)
+     &*xb),cone)
       g124 = hp_glog((cone*(-(r1*(1 - xb)) + xa**2*(-1 + xb)*xb))/((-1 + xa)*xa*(-1 + xb)**2),cone,cone)
-      g125 = hp_glog((cone*(-(r1*(1 - xb)) + xa**2*(-1 + xb)*xb))/((-1 + xa)*xa*(-1 + xb)**2),(cone*(1 + xa)*xb)/(xa*(-1 + xb)),cone)
-      g126 = hp_glog((cone*(-(r1*(1 - xb)) + xa**2*(-1 + xb)*xb))/((-1 + xa)*xa*(-1 + xb)**2),(cone*(1 + xa)*(1 + xb))/((-1 + xa)*(-1 + xb)),cone)
-      g127 = hp_glog((cone*(-(r1*(1 - xb)) + xa**2*(-1 + xb)*xb))/((-1 + xa)*xa*(-1 + xb)**2),(cone*(-(r1*(1 - xb)) + xa**2*(-1 + xb)*xb))/((-1 + xa)*xa*(-1 + xb)**2),cone)
-      g128 = hp_glog((cone*(-(r1*(1 - xb)) + xa**2*(-1 + xb)*xb))/((-1 + xa)*xa*(-1 + xb)**2),(cone*(r1*(1 - xb) + xa**2*(-1 + xb)*xb))/((-1 + xa)*xa*(-1 + xb)**2),cone)
+      g125 = hp_glog((cone*(-(r1*(1 - xb)) + xa**2*(-1 + xb)*xb))/((-1 + xa)*xa*(-1 + xb)**2),(cone*(1 + xa)*xb)/(xa*(-1 + xb)),
+     &cone)
+      g126 = hp_glog((cone*(-(r1*(1 - xb)) + xa**2*(-1 + xb)*xb))/((-1 + xa)*xa*(-1 + xb)**2),(cone*(1 + xa)*(1 + xb))/((-1 + xa)*(-
+     &1 + xb)),cone)
+      g127 = hp_glog((cone*(-(r1*(1 - xb)) + xa**2*(-1 + xb)*xb))/((-1 + xa)*xa*(-1 + xb)**2),(cone*(-(r1*(1 - xb)) + xa**2*(-1 + 
+     &xb)*xb))/((-1 + xa)*xa*(-1 + xb)**2),cone)
+      g128 = hp_glog((cone*(-(r1*(1 - xb)) + xa**2*(-1 + xb)*xb))/((-1 + xa)*xa*(-1 + xb)**2),(cone*(r1*(1 - xb) + xa**2*(-1 + xb)
+     &*xb))/((-1 + xa)*xa*(-1 + xb)**2),cone)
       g129 = hp_glog((cone*(r1*(1 - xb) + xa**2*(-1 + xb)*xb))/((-1 + xa)*xa*(-1 + xb)**2),cone,cone)
       g130 = hp_glog((cone*(r1*(1 - xb) + xa**2*(-1 + xb)*xb))/((-1 + xa)*xa*(-1 + xb)**2),(cone*(1 + xa)*xb)/(xa*(-1 + xb)),cone)
-      g131 = hp_glog((cone*(r1*(1 - xb) + xa**2*(-1 + xb)*xb))/((-1 + xa)*xa*(-1 + xb)**2),(cone*(1 + xa)*(1 + xb))/((-1 + xa)*(-1 + xb)),cone)
-      g132 = hp_glog((cone*(r1*(1 - xb) + xa**2*(-1 + xb)*xb))/((-1 + xa)*xa*(-1 + xb)**2),(cone*(-(r1*(1 - xb)) + xa**2*(-1 + xb)*xb))/((-1 + xa)*xa*(-1 + xb)**2),cone)
-      g133 = hp_glog((cone*(r1*(1 - xb) + xa**2*(-1 + xb)*xb))/((-1 + xa)*xa*(-1 + xb)**2),(cone*(r1*(1 - xb) + xa**2*(-1 + xb)*xb))/((-1 + xa)*xa*(-1 + xb)**2),cone)
+      g131 = hp_glog((cone*(r1*(1 - xb) + xa**2*(-1 + xb)*xb))/((-1 + xa)*xa*(-1 + xb)**2),(cone*(1 + xa)*(1 + xb))/((-1 + xa)*(-1 +
+     & xb)),cone)
+      g132 = hp_glog((cone*(r1*(1 - xb) + xa**2*(-1 + xb)*xb))/((-1 + xa)*xa*(-1 + xb)**2),(cone*(-(r1*(1 - xb)) + xa**2*(-1 + xb)
+     &*xb))/((-1 + xa)*xa*(-1 + xb)**2),cone)
+      g133 = hp_glog((cone*(r1*(1 - xb) + xa**2*(-1 + xb)*xb))/((-1 + xa)*xa*(-1 + xb)**2),(cone*(r1*(1 - xb) + xa**2*(-1 + xb)*xb))
+     &/((-1 + xa)*xa*(-1 + xb)**2),cone)
       g134 = hp_glog(-((cone*(r2*(1 - xa) + xa*xb**2 - xa**2*xb**2))/((-1 + xa)**2*(-1 + xb)*xb)),cone,cone)
-      g135 = hp_glog(-((cone*(r2*(1 - xa) + xa*xb**2 - xa**2*xb**2))/((-1 + xa)**2*(-1 + xb)*xb)),(cone*(1 + xa)*(1 + xb))/((-1 + xa)*(-1 + xb)),cone)
-      g136 = hp_glog(-((cone*(r2*(1 - xa) + xa*xb**2 - xa**2*xb**2))/((-1 + xa)**2*(-1 + xb)*xb)),(cone*xa*(1 + xb))/((-1 + xa)*xb),cone)
-      g137 = hp_glog(-((cone*(r2*(1 - xa) + xa*xb**2 - xa**2*xb**2))/((-1 + xa)**2*(-1 + xb)*xb)),-((cone*(r2*(1 - xa) + xa*xb**2 - xa**2*xb**2))/((-1 + xa)**2*(-1 + xb)*xb)),cone)
-      g138 = hp_glog(-((cone*(r2*(1 - xa) + xa*xb**2 - xa**2*xb**2))/((-1 + xa)**2*(-1 + xb)*xb)),(cone*(r2*(1 - xa) - xa*xb**2 + xa**2*xb**2))/((-1 + xa)**2*(-1 + xb)*xb),cone)
+      g135 = hp_glog(-((cone*(r2*(1 - xa) + xa*xb**2 - xa**2*xb**2))/((-1 + xa)**2*(-1 + xb)*xb)),(cone*(1 + xa)*(1 + xb))/((-1 + 
+     &xa)*(-1 + xb)),cone)
+      g136 = hp_glog(-((cone*(r2*(1 - xa) + xa*xb**2 - xa**2*xb**2))/((-1 + xa)**2*(-1 + xb)*xb)),(cone*xa*(1 + xb))/((-1 + xa)*xb),
+     &cone)
+      g137 = hp_glog(-((cone*(r2*(1 - xa) + xa*xb**2 - xa**2*xb**2))/((-1 + xa)**2*(-1 + xb)*xb)),-((cone*(r2*(1 - xa) + xa*xb**2 - 
+     &xa**2*xb**2))/((-1 + xa)**2*(-1 + xb)*xb)),cone)
+      g138 = hp_glog(-((cone*(r2*(1 - xa) + xa*xb**2 - xa**2*xb**2))/((-1 + xa)**2*(-1 + xb)*xb)),(cone*(r2*(1 - xa) - xa*xb**2 + 
+     &xa**2*xb**2))/((-1 + xa)**2*(-1 + xb)*xb),cone)
       g139 = hp_glog((cone*(r2*(1 - xa) - xa*xb**2 + xa**2*xb**2))/((-1 + xa)**2*(-1 + xb)*xb),cone,cone)
-      g140 = hp_glog((cone*(r2*(1 - xa) - xa*xb**2 + xa**2*xb**2))/((-1 + xa)**2*(-1 + xb)*xb),(cone*(1 + xa)*(1 + xb))/((-1 + xa)*(-1 + xb)),cone)
-      g141 = hp_glog((cone*(r2*(1 - xa) - xa*xb**2 + xa**2*xb**2))/((-1 + xa)**2*(-1 + xb)*xb),(cone*xa*(1 + xb))/((-1 + xa)*xb),cone)
-      g142 = hp_glog((cone*(r2*(1 - xa) - xa*xb**2 + xa**2*xb**2))/((-1 + xa)**2*(-1 + xb)*xb),-((cone*(r2*(1 - xa) + xa*xb**2 - xa**2*xb**2))/((-1 + xa)**2*(-1 + xb)*xb)),cone)
-      g143 = hp_glog((cone*(r2*(1 - xa) - xa*xb**2 + xa**2*xb**2))/((-1 + xa)**2*(-1 + xb)*xb),(cone*(r2*(1 - xa) - xa*xb**2 + xa**2*xb**2))/((-1 + xa)**2*(-1 + xb)*xb),cone)
+      g140 = hp_glog((cone*(r2*(1 - xa) - xa*xb**2 + xa**2*xb**2))/((-1 + xa)**2*(-1 + xb)*xb),(cone*(1 + xa)*(1 + xb))/((-1 + xa)*(
+     &-1 + xb)),cone)
+      g141 = hp_glog((cone*(r2*(1 - xa) - xa*xb**2 + xa**2*xb**2))/((-1 + xa)**2*(-1 + xb)*xb),(cone*xa*(1 + xb))/((-1 + xa)*xb),
+     &cone)
+      g142 = hp_glog((cone*(r2*(1 - xa) - xa*xb**2 + xa**2*xb**2))/((-1 + xa)**2*(-1 + xb)*xb),-((cone*(r2*(1 - xa) + xa*xb**2 - 
+     &xa**2*xb**2))/((-1 + xa)**2*(-1 + xb)*xb)),cone)
+      g143 = hp_glog((cone*(r2*(1 - xa) - xa*xb**2 + xa**2*xb**2))/((-1 + xa)**2*(-1 + xb)*xb),(cone*(r2*(1 - xa) - xa*xb**2 + 
+     &xa**2*xb**2))/((-1 + xa)**2*(-1 + xb)*xb),cone)

--- a/src/hp_Intcts/include/hp_a2cars_bulk_functions.h
+++ b/src/hp_Intcts/include/hp_a2cars_bulk_functions.h
@@ -251,8 +251,10 @@
       l27 = hp_mylog(-((cone*(r2*(1 - xa) - xa*xb**2 + xa**2*xb**2))/((-1 + xa)**2*(-1 + xb)*xb)))
       l28 = hp_mylog(cone*(1 - xa - xb + 2*xa*xb - 2*xa**2*xb**2 + xa**3*xb**3))
       l29 = hp_mylog(cone*(2 - xb + xa**2*xb**2 - xa*(1 + xb)))
-      l30 = hp_mylog((cone*(4*r4*xa + r5*xa - r4*xa**2 + r5*xb - 2*r4*xa*xb - xb**2.5_ki + (-r5 + r4*xa + r4*xb)*Abs(xa - xb)))/((r5 - r4*xa - r4*xb)*(xa + xb - Abs(xa - xb))))
-      l31 = hp_mylog((cone*(-4*r4*xa + r5*xa + r4*xa**2 + r5*xb + 2*r4*xa*xb + xb**2.5_ki - (r5 + r4*xa + r4*xb)*Abs(xa - xb)))/((r5 + r4*xa + r4*xb)*(xa + xb - Abs(xa - xb))))
+      l30 = hp_mylog((cone*(4*r4*xa + r5*xa - r4*xa**2 + r5*xb - 2*r4*xa*xb - xb**2.5_ki + (-r5 + r4*xa + r4*xb)*Abs(xa - xb)))/((
+     &r5 - r4*xa - r4*xb)*(xa + xb - Abs(xa - xb))))
+      l31 = hp_mylog((cone*(-4*r4*xa + r5*xa + r4*xa**2 + r5*xb + 2*r4*xa*xb + xb**2.5_ki - (r5 + r4*xa + r4*xb)*Abs(xa - xb)))/((
+     &r5 + r4*xa + r4*xb)*(xa + xb - Abs(xa - xb))))
       g1 = hp_glog(-2*cone,-cone,cone*xb)
       g2 = hp_glog(-2*cone,czip,cone*xb)
       g3 = hp_glog(-2*cone,2*cone,cone*xb)
@@ -354,8 +356,10 @@
       g99 = hp_glog((cone*xa*(1 + xb))/((-1 + xa)*xb),(cone*xa*(1 + xb))/((-1 + xa)*xb),cone)
       g100 = hp_glog((cone*xa*(1 + xb))/((-1 + xa)*xb),(cone*(1 - r1 + 2*xa*xb))/(2 - 2*xa - 2*xb + 2*xa*xb),cone)
       g101 = hp_glog((cone*xa*(1 + xb))/((-1 + xa)*xb),(cone*(1 + r1 + 2*xa*xb))/(2 - 2*xa - 2*xb + 2*xa*xb),cone)
-      g102 = hp_glog((cone*xa*(1 + xb))/((-1 + xa)*xb),-((cone*(r2*(1 - xa) + xa*xb**2 - xa**2*xb**2))/((-1 + xa)**2*(-1 + xb)*xb)),cone)
-      g103 = hp_glog((cone*xa*(1 + xb))/((-1 + xa)*xb),(cone*(r2*(1 - xa) - xa*xb**2 + xa**2*xb**2))/((-1 + xa)**2*(-1 + xb)*xb),cone)
+      g102 = hp_glog((cone*xa*(1 + xb))/((-1 + xa)*xb),-((cone*(r2*(1 - xa) + xa*xb**2 - xa**2*xb**2))/((-1 + xa)**2*(-1 + xb)*xb)),
+     &cone)
+      g103 = hp_glog((cone*xa*(1 + xb))/((-1 + xa)*xb),(cone*(r2*(1 - xa) - xa*xb**2 + xa**2*xb**2))/((-1 + xa)**2*(-1 + xb)*xb),
+     &cone)
       g104 = hp_glog((cone*(-r5 + r4*xa + r4*xb))/(2.0_ki*r3),czip,cone/(r3*r4))
       g105 = hp_glog((cone*(-r5 + r4*xa + r4*xb))/(2.0_ki*r3),czip,(2*cone*r3*r4)/(xa + xb - Abs(xa - xb)))
       g106 = hp_glog((cone*(-r5 + r4*xa + r4*xb))/(2.0_ki*r3),cone/(r3*r4),cone/(r3*r4))
@@ -373,8 +377,10 @@
       g118 = hp_glog((cone*(-1 + xa*xb))/((-1 + xa)*(-1 + xb)),(cone*(1 + xb))/(1 - xa),cone)
       g119 = hp_glog((cone*(-1 + xa*xb))/((-1 + xa)*(-1 + xb)),(cone*(1 + xa)*(1 + xb))/((-1 + xa)*(-1 + xb)),cone)
       g120 = hp_glog((cone*(-1 + xa*xb))/((-1 + xa)*(-1 + xb)),(cone*xa*(1 + xb))/((-1 + xa)*xb),cone)
-      g121 = hp_glog((cone*(-1 + xa*xb))/((-1 + xa)*(-1 + xb)),-((cone*(r2*(1 - xa) + xa*xb**2 - xa**2*xb**2))/((-1 + xa)**2*(-1 + xb)*xb)),cone)
-      g122 = hp_glog((cone*(-1 + xa*xb))/((-1 + xa)*(-1 + xb)),(cone*(r2*(1 - xa) - xa*xb**2 + xa**2*xb**2))/((-1 + xa)**2*(-1 + xb)*xb),cone)
+      g121 = hp_glog((cone*(-1 + xa*xb))/((-1 + xa)*(-1 + xb)),-((cone*(r2*(1 - xa) + xa*xb**2 - xa**2*xb**2))/((-1 + xa)**2*(-1 + 
+     &xb)*xb)),cone)
+      g122 = hp_glog((cone*(-1 + xa*xb))/((-1 + xa)*(-1 + xb)),(cone*(r2*(1 - xa) - xa*xb**2 + xa**2*xb**2))/((-1 + xa)**2*(-1 + xb)
+     &*xb),cone)
       g123 = hp_glog((cone*(1 + xa*xb))/((-1 + xa)*(-1 + xb)),czip,cone)
       g124 = hp_glog((cone*(1 + xa*xb))/((-1 + xa)*(-1 + xb)),cone,cone)
       g125 = hp_glog((cone*(1 + xa*xb))/((-1 + xa)*(-1 + xb)),(cone*(1 + xb))/(1 - xa),cone)
@@ -384,21 +390,33 @@
       g129 = hp_glog((cone*(1 - r1 + 2*xa*xb))/(2 - 2*xa - 2*xb + 2*xa*xb),cone,cone)
       g130 = hp_glog((cone*(1 - r1 + 2*xa*xb))/(2 - 2*xa - 2*xb + 2*xa*xb),(cone*(1 + xa)*(1 + xb))/((-1 + xa)*(-1 + xb)),cone)
       g131 = hp_glog((cone*(1 - r1 + 2*xa*xb))/(2 - 2*xa - 2*xb + 2*xa*xb),(cone*xa*(1 + xb))/((-1 + xa)*xb),cone)
-      g132 = hp_glog((cone*(1 - r1 + 2*xa*xb))/(2 - 2*xa - 2*xb + 2*xa*xb),(cone*(1 - r1 + 2*xa*xb))/(2 - 2*xa - 2*xb + 2*xa*xb),cone)
-      g133 = hp_glog((cone*(1 - r1 + 2*xa*xb))/(2 - 2*xa - 2*xb + 2*xa*xb),(cone*(1 + r1 + 2*xa*xb))/(2 - 2*xa - 2*xb + 2*xa*xb),cone)
+      g132 = hp_glog((cone*(1 - r1 + 2*xa*xb))/(2 - 2*xa - 2*xb + 2*xa*xb),(cone*(1 - r1 + 2*xa*xb))/(2 - 2*xa - 2*xb + 2*xa*xb),
+     &cone)
+      g133 = hp_glog((cone*(1 - r1 + 2*xa*xb))/(2 - 2*xa - 2*xb + 2*xa*xb),(cone*(1 + r1 + 2*xa*xb))/(2 - 2*xa - 2*xb + 2*xa*xb),
+     &cone)
       g134 = hp_glog((cone*(1 + r1 + 2*xa*xb))/(2 - 2*xa - 2*xb + 2*xa*xb),czip,cone)
       g135 = hp_glog((cone*(1 + r1 + 2*xa*xb))/(2 - 2*xa - 2*xb + 2*xa*xb),cone,cone)
       g136 = hp_glog((cone*(1 + r1 + 2*xa*xb))/(2 - 2*xa - 2*xb + 2*xa*xb),(cone*(1 + xa)*(1 + xb))/((-1 + xa)*(-1 + xb)),cone)
       g137 = hp_glog((cone*(1 + r1 + 2*xa*xb))/(2 - 2*xa - 2*xb + 2*xa*xb),(cone*xa*(1 + xb))/((-1 + xa)*xb),cone)
-      g138 = hp_glog((cone*(1 + r1 + 2*xa*xb))/(2 - 2*xa - 2*xb + 2*xa*xb),(cone*(1 - r1 + 2*xa*xb))/(2 - 2*xa - 2*xb + 2*xa*xb),cone)
-      g139 = hp_glog((cone*(1 + r1 + 2*xa*xb))/(2 - 2*xa - 2*xb + 2*xa*xb),(cone*(1 + r1 + 2*xa*xb))/(2 - 2*xa - 2*xb + 2*xa*xb),cone)
+      g138 = hp_glog((cone*(1 + r1 + 2*xa*xb))/(2 - 2*xa - 2*xb + 2*xa*xb),(cone*(1 - r1 + 2*xa*xb))/(2 - 2*xa - 2*xb + 2*xa*xb),
+     &cone)
+      g139 = hp_glog((cone*(1 + r1 + 2*xa*xb))/(2 - 2*xa - 2*xb + 2*xa*xb),(cone*(1 + r1 + 2*xa*xb))/(2 - 2*xa - 2*xb + 2*xa*xb),
+     &cone)
       g140 = hp_glog(-((cone*(r2*(1 - xa) + xa*xb**2 - xa**2*xb**2))/((-1 + xa)**2*(-1 + xb)*xb)),cone,cone)
-      g141 = hp_glog(-((cone*(r2*(1 - xa) + xa*xb**2 - xa**2*xb**2))/((-1 + xa)**2*(-1 + xb)*xb)),(cone*(1 + xa)*(1 + xb))/((-1 + xa)*(-1 + xb)),cone)
-      g142 = hp_glog(-((cone*(r2*(1 - xa) + xa*xb**2 - xa**2*xb**2))/((-1 + xa)**2*(-1 + xb)*xb)),(cone*xa*(1 + xb))/((-1 + xa)*xb),cone)
-      g143 = hp_glog(-((cone*(r2*(1 - xa) + xa*xb**2 - xa**2*xb**2))/((-1 + xa)**2*(-1 + xb)*xb)),-((cone*(r2*(1 - xa) + xa*xb**2 - xa**2*xb**2))/((-1 + xa)**2*(-1 + xb)*xb)),cone)
-      g144 = hp_glog(-((cone*(r2*(1 - xa) + xa*xb**2 - xa**2*xb**2))/((-1 + xa)**2*(-1 + xb)*xb)),(cone*(r2*(1 - xa) - xa*xb**2 + xa**2*xb**2))/((-1 + xa)**2*(-1 + xb)*xb),cone)
+      g141 = hp_glog(-((cone*(r2*(1 - xa) + xa*xb**2 - xa**2*xb**2))/((-1 + xa)**2*(-1 + xb)*xb)),(cone*(1 + xa)*(1 + xb))/((-1 + 
+     &xa)*(-1 + xb)),cone)
+      g142 = hp_glog(-((cone*(r2*(1 - xa) + xa*xb**2 - xa**2*xb**2))/((-1 + xa)**2*(-1 + xb)*xb)),(cone*xa*(1 + xb))/((-1 + xa)*xb),
+     &cone)
+      g143 = hp_glog(-((cone*(r2*(1 - xa) + xa*xb**2 - xa**2*xb**2))/((-1 + xa)**2*(-1 + xb)*xb)),-((cone*(r2*(1 - xa) + xa*xb**2 - 
+     &xa**2*xb**2))/((-1 + xa)**2*(-1 + xb)*xb)),cone)
+      g144 = hp_glog(-((cone*(r2*(1 - xa) + xa*xb**2 - xa**2*xb**2))/((-1 + xa)**2*(-1 + xb)*xb)),(cone*(r2*(1 - xa) - xa*xb**2 + 
+     &xa**2*xb**2))/((-1 + xa)**2*(-1 + xb)*xb),cone)
       g145 = hp_glog((cone*(r2*(1 - xa) - xa*xb**2 + xa**2*xb**2))/((-1 + xa)**2*(-1 + xb)*xb),cone,cone)
-      g146 = hp_glog((cone*(r2*(1 - xa) - xa*xb**2 + xa**2*xb**2))/((-1 + xa)**2*(-1 + xb)*xb),(cone*(1 + xa)*(1 + xb))/((-1 + xa)*(-1 + xb)),cone)
-      g147 = hp_glog((cone*(r2*(1 - xa) - xa*xb**2 + xa**2*xb**2))/((-1 + xa)**2*(-1 + xb)*xb),(cone*xa*(1 + xb))/((-1 + xa)*xb),cone)
-      g148 = hp_glog((cone*(r2*(1 - xa) - xa*xb**2 + xa**2*xb**2))/((-1 + xa)**2*(-1 + xb)*xb),-((cone*(r2*(1 - xa) + xa*xb**2 - xa**2*xb**2))/((-1 + xa)**2*(-1 + xb)*xb)),cone)
-      g149 = hp_glog((cone*(r2*(1 - xa) - xa*xb**2 + xa**2*xb**2))/((-1 + xa)**2*(-1 + xb)*xb),(cone*(r2*(1 - xa) - xa*xb**2 + xa**2*xb**2))/((-1 + xa)**2*(-1 + xb)*xb),cone)
+      g146 = hp_glog((cone*(r2*(1 - xa) - xa*xb**2 + xa**2*xb**2))/((-1 + xa)**2*(-1 + xb)*xb),(cone*(1 + xa)*(1 + xb))/((-1 + xa)*(
+     &-1 + xb)),cone)
+      g147 = hp_glog((cone*(r2*(1 - xa) - xa*xb**2 + xa**2*xb**2))/((-1 + xa)**2*(-1 + xb)*xb),(cone*xa*(1 + xb))/((-1 + xa)*xb),
+     &cone)
+      g148 = hp_glog((cone*(r2*(1 - xa) - xa*xb**2 + xa**2*xb**2))/((-1 + xa)**2*(-1 + xb)*xb),-((cone*(r2*(1 - xa) + xa*xb**2 - 
+     &xa**2*xb**2))/((-1 + xa)**2*(-1 + xb)*xb)),cone)
+      g149 = hp_glog((cone*(r2*(1 - xa) - xa*xb**2 + xa**2*xb**2))/((-1 + xa)**2*(-1 + xb)*xb),(cone*(r2*(1 - xa) - xa*xb**2 + 
+     &xa**2*xb**2))/((-1 + xa)**2*(-1 + xb)*xb),cone)

--- a/src/hp_Intcts/include/hp_cts.h
+++ b/src/hp_Intcts/include/hp_cts.h
@@ -57,7 +57,8 @@
      1  na1a1cassssragg(0:2,0:2,-4:0),
      2  na1a1sscarsragg(0:2,0:2,-4:0),
      3  na1a1sssrgg(0:2,0:2,-4:0),
-     4  na1a1crssscarggg(0:2,0:2,-4:0), na1a1crssscargqg(0:2,0:2,-4:0), na1a1crssscarqgg(0:2,0:2,-4:0), na1a1crssscarqqg(0:2,0:2,-4:0),
+     4  na1a1crssscarggg(0:2,0:2,-4:0), na1a1crssscargqg(0:2,0:2,-4:0), na1a1crssscarqgg(0:2,0:2,-4:0), na1a1crssscarqqg(0:2,0:2,-
+     &4:0),
      5  na1a1sscarggg(0:2,0:2,-4:0), na1a1sscargqg(0:2,0:2,-4:0), na1a1sscarqgg(0:2,0:2,-4:0), na1a1sscarqqg(0:2,0:2,-4:0)
 
 	


### PR DESCRIPTION
Limit the length of the lines in codes to 132 characters

The transformation was done with the attached python script.
[splitter.py](https://github.com/user-attachments/files/22423317/splitter.py)
